### PR TITLE
test: support dockerhub mirror for tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -81,3 +81,9 @@ def pytest_addoption(parser: Parser):
         help="The no proxy URL(s) to apply on the Openstack runners.",
         default=None,
     )
+    parser.addoption(
+        "--dockerhub-mirror",
+        action="store",
+        help="The dockerhub mirror URL to reduce API rate limiting.",
+        default=None,
+    )

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -189,6 +189,12 @@ def openstack_connection_fixture(clouds_yaml_contents: str) -> Connection:
     return openstack.connect(first_cloud)
 
 
+@pytest.fixture(scope="module", name="dockerhub_mirror")
+def dockerhub_mirror_fixture(pytestconfig: pytest.Config) -> str | None:
+    """Dockerhub mirror URL."""
+    return pytestconfig.getoption("--dockerhub-mirror")
+
+
 @pytest.fixture(scope="module", name="test_id")
 def test_id_fixture() -> str:
     """The test ID fixture."""
@@ -350,7 +356,10 @@ async def openstack_server_fixture(
 
 @pytest_asyncio.fixture(scope="module", name="ssh_connection")
 async def ssh_connection_fixture(
-    openstack_server: Server, openstack_metadata: OpenstackMeta, proxy: ProxyConfig
+    openstack_server: Server,
+    openstack_metadata: OpenstackMeta,
+    proxy: ProxyConfig,
+    dockerhub_mirror: str | None,
 ) -> SSHConnection:
     """The openstack server ssh connection fixture."""
     logger.info("Setting up SSH connection.")
@@ -360,6 +369,7 @@ async def ssh_connection_fixture(
         network=openstack_metadata.network,
         ssh_key=openstack_metadata.ssh_key.private_key,
         proxy=proxy,
+        dockerhub_mirror=dockerhub_mirror,
     )
 
     return ssh_connection

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -73,7 +73,7 @@ def _configure_dockerhub_mirror(conn: SSHConnection, dockerhub_mirror: str | Non
     """
     if not dockerhub_mirror:
         return
-    command = f'echo {{ "registry-mirrors": ["{dockerhub_mirror}"]}} > /etc/docker/daemon.json'
+    command = f'echo "{{ "registry-mirrors": ["{dockerhub_mirror}"] }}" > /etc/docker/daemon.json'
     logger.info("Running command: %s", command)
     result: Result = conn.run(command)
     assert result.ok, "Failed to setup DockerHub mirror"

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -73,17 +73,19 @@ def _configure_dockerhub_mirror(conn: SSHConnection, dockerhub_mirror: str | Non
     """
     if not dockerhub_mirror:
         return
-    command = f'echo "{{ "registry-mirrors": ["{dockerhub_mirror}"] }}" | \
-sudo tee /etc/docker/daemon.json'
+    command = f"""echo '{{ "registry-mirrors": ["{dockerhub_mirror}"] }}' | \
+sudo tee /etc/docker/daemon.json"""
     logger.info("Running command: %s", command)
     result: Result = conn.run(command)
     assert result.ok, "Failed to setup DockerHub mirror"
 
     command = "sudo systemctl daemon-reload"
+    logger.info("Running command: %s", command)
     result = conn.run(command)
     assert result.ok, "Failed to reload daemon"
 
     command = "sudo systemctl restart docker"
+    logger.info("Running command: %s", command)
     result = conn.run(command)
     assert result.ok, "Failed to restart docker"
 

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -73,7 +73,8 @@ def _configure_dockerhub_mirror(conn: SSHConnection, dockerhub_mirror: str | Non
     """
     if not dockerhub_mirror:
         return
-    command = f'echo "{{ "registry-mirrors": ["{dockerhub_mirror}"] }}" > /etc/docker/daemon.json'
+    command = f'echo "{{ "registry-mirrors": ["{dockerhub_mirror}"] }}" | \
+sudo tee /etc/docker/daemon.json'
     logger.info("Running command: %s", command)
     result: Result = conn.run(command)
     assert result.ok, "Failed to setup DockerHub mirror"

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -75,7 +75,7 @@ def _install_dockerhub_mirror(conn: SSHConnection, dockerhub_mirror: str | None)
     if not dockerhub_mirror:
         return
     command = f'echo {{ "registry-mirrors": ["{dockerhub_mirror}"]}} > /etc/docker/daemon.json'
-    logger.info("Runing command: %s", command)
+    logger.info("Running command: %s", command)
     result: Result = conn.run(command)
     assert result.ok, "Failed to setup DockerHub mirror"
 


### PR DESCRIPTION
Applicable spec: N/A

### Overview

Add support for dockerhub mirror for tests

### Rationale

Tests get timeout error due to rate limiting

### Juju Events Changes

N/A

### Module Changes

N/A

### Library Changes

None.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
