### PR TITLE
chore: private endpoint juju access

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -19,6 +19,8 @@ jobs:
       self-hosted-runner-arch: X64
       self-hosted-runner-label: stg-private-endpoint
       builder-runner-label: X64
+      tmate-debug: true
+      tmate-timeout: 60
 
   integration-tests-arm:
     uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@feat/private_endpoint
@@ -32,5 +34,3 @@ jobs:
       self-hosted-runner-label: stg-private-endpoint
       builder-runner-label: ARM64
       pre-run-script: tests/integration/setup_private_endpoint.sh
-      tmate-debug: true
-      tmate-timeout: 60

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -32,3 +32,5 @@ jobs:
       self-hosted-runner-label: stg-private-endpoint
       builder-runner-label: ARM64
       pre-run-script: tests/integration/setup_private_endpoint.sh
+      tmate-debug: true
+      tmate-timeout: 60

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -19,8 +19,6 @@ jobs:
       self-hosted-runner-arch: X64
       self-hosted-runner-label: stg-private-endpoint
       builder-runner-label: X64
-      tmate-debug: true
-      tmate-timeout: 60
 
   integration-tests-arm:
     uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@feat/private_endpoint

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -21,7 +21,7 @@ jobs:
       builder-runner-label: X64
 
   integration-tests-arm:
-    uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@feat/private_endpoint
+    uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
     secrets: inherit
     with:
       juju-channel: 3.2/stable

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -21,7 +21,7 @@ jobs:
       builder-runner-label: X64
 
   integration-tests-arm:
-    uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@private_endpoint
+    uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@feat/private_endpoint
     secrets: inherit
     with:
       juju-channel: 3.2/stable

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -31,3 +31,4 @@ jobs:
       self-hosted-runner-arch: ARM64
       self-hosted-runner-label: stg-private-endpoint
       builder-runner-label: ARM64
+      pre-run-script: tests/integration/setup_private_endpoint.sh

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -21,7 +21,7 @@ jobs:
       builder-runner-label: X64
 
   integration-tests-arm:
-    uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
+    uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@private_endpoint
     secrets: inherit
     with:
       juju-channel: 3.2/stable

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,47 +25,47 @@ def pytest_addoption(parser: Parser):
     )
     # Private endpoint options ARM64
     parser.addoption(
-        "--openstack-network-name",
+        "--openstack-network-name-arm64",
         action="store",
         help="The Openstack network to create testing instances under.",
     )
     parser.addoption(
-        "--openstack-flavor-name",
+        "--openstack-flavor-name-arm64",
         action="store",
         help="The Openstack flavor to create testing instances with.",
     )
     parser.addoption(
-        "--openstack-auth-url",
+        "--openstack-auth-url-arm64",
         action="store",
         help="The URL to Openstack authentication service, i.e. keystone.",
     )
     parser.addoption(
-        "--openstack-password",
+        "--openstack-password-arm64",
         action="store",
         help="The password to authenticate to Openstack service.",
     )
     parser.addoption(
-        "--openstack-project-domain-name",
+        "--openstack-project-domain-name-arm64",
         action="store",
         help="The Openstack project domain name to use.",
     )
     parser.addoption(
-        "--openstack-project-name",
+        "--openstack-project-name-arm64",
         action="store",
         help="The Openstack project name to use.",
     )
     parser.addoption(
-        "--openstack-user-domain-name",
+        "--openstack-user-domain-name-arm64",
         action="store",
         help="The Openstack user domain name to use.",
     )
     parser.addoption(
-        "--openstack-user-name",
+        "--openstack-user-name-arm64",
         action="store",
         help="The Openstack user to authenticate as.",
     )
     parser.addoption(
-        "--openstack-region-name",
+        "--openstack-region-name-arm64",
         action="store",
         help="The Openstack region to authenticate to.",
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,6 +23,7 @@ def pytest_addoption(parser: Parser):
         action="store",
         help="The OpenStack clouds yaml contents the charm uses to connect to Openstack.",
     )
+    # Private endpoint options ARM64
     parser.addoption(
         "--openstack-network-name",
         action="store",
@@ -33,7 +34,6 @@ def pytest_addoption(parser: Parser):
         action="store",
         help="The Openstack flavor to create testing instances with.",
     )
-    # Private endpoint options
     parser.addoption(
         "--openstack-auth-url",
         action="store",
@@ -69,6 +69,53 @@ def pytest_addoption(parser: Parser):
         action="store",
         help="The Openstack region to authenticate to.",
     )
+    # Private endpoint options AMD64
+    parser.addoption(
+        "--openstack-network-name-amd64",
+        action="store",
+        help="The Openstack network to create testing instances under.",
+    )
+    parser.addoption(
+        "--openstack-flavor-name-amd64",
+        action="store",
+        help="The Openstack flavor to create testing instances with.",
+    )
+    parser.addoption(
+        "--openstack-auth-url-amd64",
+        action="store",
+        help="The URL to Openstack authentication service, i.e. keystone.",
+    )
+    parser.addoption(
+        "--openstack-password-amd64",
+        action="store",
+        help="The password to authenticate to Openstack service.",
+    )
+    parser.addoption(
+        "--openstack-project-domain-name-amd64",
+        action="store",
+        help="The Openstack project domain name to use.",
+    )
+    parser.addoption(
+        "--openstack-project-name-amd64",
+        action="store",
+        help="The Openstack project name to use.",
+    )
+    parser.addoption(
+        "--openstack-user-domain-name-amd64",
+        action="store",
+        help="The Openstack user domain name to use.",
+    )
+    parser.addoption(
+        "--openstack-user-name-amd64",
+        action="store",
+        help="The Openstack user to authenticate as.",
+    )
+    parser.addoption(
+        "--openstack-region-name-amd64",
+        action="store",
+        help="The Openstack region to authenticate to.",
+    )
+    # Shared private endpoint options
     parser.addoption(
         "--proxy",
         action="store",

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -37,7 +37,7 @@ from state import (
     REVISION_HISTORY_LIMIT_CONFIG_NAME,
     _get_supported_arch,
 )
-from tests.integration.helpers import get_juju_arch, wait_for_valid_connection, wait_juju_deploy
+from tests.integration.helpers import get_juju_arch, wait_for_valid_connection
 from tests.integration.types import PrivateEndpointConfigs, ProxyConfig, SSHKey
 
 logger = logging.getLogger(__name__)
@@ -102,8 +102,7 @@ async def test_charm_fixture(model: Model) -> AsyncGenerator[Application, None]:
     build_cmd = ["charmcraft", "pack", "-p", "tests/integration/data/charm"]
     subprocess.check_call(build_cmd)
     logger.info("Deploying built test charm.")
-    await wait_juju_deploy(f"./test_ubuntu-22.04-{get_juju_arch()}.charm")
-    app = Application(entity_id="test", model=model, connected=False)
+    app = await model.deploy(f"./test_ubuntu-22.04-{get_juju_arch()}.charm")
 
     yield app
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -248,9 +248,10 @@ async def app_fixture(
         OPENSTACK_USER_DOMAIN_CONFIG_NAME: private_endpoint_configs["user_domain_name"],
     }
 
-    base_machine_constraint = f"arch={get_juju_arch()} cores=4 mem=16G root-disk=20G"
+    arch = get_juju_arch()
+    base_machine_constraint = f"arch={arch} cores=4 mem=16G root-disk=20G"
     # if local LXD testing model, make the machine of VM type
-    if model == "testing":
+    if "test" in model.name and arch == "amd64":
         base_machine_constraint += " virt-type=virtual-machine"
     app: Application = await model.deploy(
         charm_file,

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -97,7 +97,7 @@ async def model_fixture(
 @pytest_asyncio.fixture(scope="module", name="test_charm")
 async def test_charm_fixture(model: Model) -> AsyncGenerator[Application, None]:
     """The test charm that becomes active when valid relation data is given."""
-    build_cmd = ["charmcraft", "pack", "-p", "tests/integration/data/charm", "-o", "."]
+    build_cmd = ["charmcraft", "pack", "-p", "tests/integration/data/charm"]
     subprocess.check_call(build_cmd)
     app = await model.deploy(f"./test_ubuntu_22.04-{get_juju_arch()}.charm")
     await model.wait_for_idle(apps=[app.name])

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -9,6 +9,7 @@ import subprocess
 from pathlib import Path
 from typing import AsyncGenerator, Generator, NamedTuple, Optional
 
+import nest_asyncio
 import openstack
 import pytest
 import pytest_asyncio
@@ -41,6 +42,9 @@ from tests.integration.helpers import get_juju_arch, wait_for_valid_connection, 
 from tests.integration.types import PrivateEndpointConfigs, ProxyConfig, SSHKey
 
 logger = logging.getLogger(__name__)
+
+# This is required to dynamically load async fixtures in async def model_fixture()
+nest_asyncio.apply()
 
 
 @pytest.fixture(scope="module", name="charm_file")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -68,7 +68,7 @@ def use_private_endpoint_fixture(pytestconfig: pytest.Config) -> bool:
 @pytest_asyncio.fixture(scope="module", name="model")
 async def model_fixture(
     request: pytest.FixtureRequest, proxy: ProxyConfig, use_private_endpoint: bool
-) -> AsyncGenerator[Model]:
+) -> AsyncGenerator[Model, None]:
     """Juju model used in the test."""
     model: Model
     if use_private_endpoint:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -99,11 +99,14 @@ async def test_charm_fixture(model: Model) -> AsyncGenerator[Application, None]:
     """The test charm that becomes active when valid relation data is given."""
     build_cmd = ["charmcraft", "pack", "-p", "tests/integration/data/charm"]
     subprocess.check_call(build_cmd)
+    logger.info("Deploying built test charm.")
     app = await model.deploy(f"./test_ubuntu_22.04-{get_juju_arch()}.charm")
+    logger.info("Wait for test charm to become active/idle.")
     await model.wait_for_idle(apps=[app.name])
 
     yield app
 
+    logger.info("Cleaning up test charm.")
     await model.remove_application(app.name)
 
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -37,7 +37,7 @@ from state import (
     REVISION_HISTORY_LIMIT_CONFIG_NAME,
     _get_supported_arch,
 )
-from tests.integration.helpers import get_juju_arch, wait_for_valid_connection
+from tests.integration.helpers import get_juju_arch, wait_for_valid_connection, wait_juju_deploy
 from tests.integration.types import PrivateEndpointConfigs, ProxyConfig, SSHKey
 
 logger = logging.getLogger(__name__)
@@ -102,7 +102,8 @@ async def test_charm_fixture(model: Model) -> AsyncGenerator[Application, None]:
     build_cmd = ["charmcraft", "pack", "-p", "tests/integration/data/charm"]
     subprocess.check_call(build_cmd)
     logger.info("Deploying built test charm.")
-    app = await model.deploy(f"./test_ubuntu-22.04-{get_juju_arch()}.charm")
+    await wait_juju_deploy(f"./test_ubuntu-22.04-{get_juju_arch()}.charm")
+    app = Application(entity_id="test", model=model, connected=False)
 
     yield app
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -74,10 +74,7 @@ def use_private_endpoint_fixture(pytestconfig: pytest.Config) -> bool:
 
 @pytest_asyncio.fixture(scope="module", name="model")
 async def model_fixture(
-    request: pytest.FixtureRequest,
-    proxy: ProxyConfig,
-    use_private_endpoint: bool,
-    config: pytest.Config,
+    request: pytest.FixtureRequest, proxy: ProxyConfig, use_private_endpoint: bool
 ) -> AsyncGenerator[Model, None]:
     """Juju model used in the test."""
     model: Model
@@ -87,9 +84,9 @@ async def model_fixture(
         yield model
         await model.disconnect()
     else:
-        config.option.cloud = None
-        config.option.controller = None
-        config.option.model = None
+        request.config.option.cloud = None
+        request.config.option.controller = None
+        request.config.option.model = None
         ops_test: OpsTest = request.getfixturevalue("ops_test")
         assert ops_test.model is not None
         # Check if private endpoint Juju model is being used. If not, configure proxy.

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -110,7 +110,7 @@ async def test_charm_fixture(model: Model, test_id: str) -> AsyncGenerator[Appli
     subprocess.check_call(build_cmd)
     logger.info("Deploying built test charm.")
     app_name = f"test-{test_id}"
-    await juju_cli_deploy(f"./test_ubuntu-22.04-{get_juju_arch()}.charm", name=app_name)
+    juju_cli_deploy(f"./test_ubuntu-22.04-{get_juju_arch()}.charm", name=app_name)
     app = Application(entity_id=app_name, model=model, connected=False)
 
     yield app

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -102,7 +102,7 @@ async def test_charm_fixture(model: Model) -> AsyncGenerator[Application, None]:
     build_cmd = ["charmcraft", "pack", "-p", "tests/integration/data/charm"]
     subprocess.check_call(build_cmd)
     logger.info("Deploying built test charm.")
-    await wait_juju_deploy(f"./test_ubuntu_22.04-{get_juju_arch()}.charm")
+    await wait_juju_deploy(f"./test_ubuntu-22.04-{get_juju_arch()}.charm")
     app = Application(entity_id="test", model=model, connected=False)
 
     yield app

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -110,7 +110,11 @@ async def test_charm_fixture(model: Model, test_id: str) -> AsyncGenerator[Appli
     subprocess.check_call(build_cmd)
     logger.info("Deploying built test charm.")
     app_name = f"test-{test_id}"
-    await juju_cli_deploy(f"./test_ubuntu-22.04-{get_juju_arch()}.charm", name=app_name, status="unknown")
+    # the test app does not set status until a proper integration is established, hence wait for
+    # unknown status
+    await juju_cli_deploy(
+        f"./test_ubuntu-22.04-{get_juju_arch()}.charm", name=app_name, status="unknown"
+    )
     app = Application(entity_id=app_name, model=model, connected=False)
 
     yield app

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -38,7 +38,7 @@ from state import (
     REVISION_HISTORY_LIMIT_CONFIG_NAME,
     _get_supported_arch,
 )
-from tests.integration.helpers import get_juju_arch, wait_for_valid_connection, wait_juju_deploy
+from tests.integration.helpers import get_juju_arch, juju_cli_deploy, wait_for_valid_connection
 from tests.integration.types import PrivateEndpointConfigs, ProxyConfig, SSHKey
 
 logger = logging.getLogger(__name__)
@@ -110,7 +110,7 @@ async def test_charm_fixture(model: Model, test_id: str) -> AsyncGenerator[Appli
     subprocess.check_call(build_cmd)
     logger.info("Deploying built test charm.")
     app_name = f"test-{test_id}"
-    await wait_juju_deploy(f"./test_ubuntu-22.04-{get_juju_arch()}.charm", name=app_name)
+    await juju_cli_deploy(f"./test_ubuntu-22.04-{get_juju_arch()}.charm", name=app_name)
     app = Application(entity_id=app_name, model=model, connected=False)
 
     yield app

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -74,7 +74,10 @@ def use_private_endpoint_fixture(pytestconfig: pytest.Config) -> bool:
 
 @pytest_asyncio.fixture(scope="module", name="model")
 async def model_fixture(
-    request: pytest.FixtureRequest, proxy: ProxyConfig, use_private_endpoint: bool
+    request: pytest.FixtureRequest,
+    proxy: ProxyConfig,
+    use_private_endpoint: bool,
+    config: pytest.Config,
 ) -> AsyncGenerator[Model, None]:
     """Juju model used in the test."""
     model: Model
@@ -84,6 +87,9 @@ async def model_fixture(
         yield model
         await model.disconnect()
     else:
+        config.option.cloud = None
+        config.option.controller = None
+        config.option.model = None
         ops_test: OpsTest = request.getfixturevalue("ops_test")
         assert ops_test.model is not None
         # Check if private endpoint Juju model is being used. If not, configure proxy.

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -63,15 +63,17 @@ async def model_fixture(ops_test: OpsTest, proxy: ProxyConfig) -> Model:
     """Juju model used in the test."""
     assert ops_test.model is not None
 
-    # Set model proxy for the runners
-
-    await ops_test.model.set_config(
-        {
-            "juju-http-proxy": proxy.http,
-            "juju-https-proxy": proxy.https,
-            "juju-no-proxy": proxy.no_proxy,
-        }
-    )
+    # Check if private endpoint Juju model is being used. If not, configure proxy.
+    # Note that "testing" is the name of the default testing model in operator-workflows.
+    if ops_test.model == "testing":
+        # Set model proxy for the runners
+        await ops_test.model.set_config(
+            {
+                "juju-http-proxy": proxy.http,
+                "juju-https-proxy": proxy.https,
+                "juju-no-proxy": proxy.no_proxy,
+            }
+        )
     return ops_test.model
 
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -85,7 +85,7 @@ def use_private_endpoint_fixture(
     pytestconfig: pytest.Config, arch: Literal["amd64", "arm64"]
 ) -> bool:
     """Whether the private endpoint is used."""
-    openstack_auth_url = pytestconfig.getoption("--openstack-auth-url")
+    openstack_auth_url = pytestconfig.getoption("--openstack-auth-url-arm64")
     # ARM64 requires private endpoint testing because we cannot test in LXD models due to nested
     # virtualization limitations.
     return bool(openstack_auth_url) and arch == "arm64"
@@ -153,7 +153,7 @@ def network_name_fixture(pytestconfig: pytest.Config, arch: Literal["amd64", "ar
     """Network to use to spawn test instances under."""
     network_name: str
     if arch == "arm64":
-        network_name = pytestconfig.getoption("--openstack-network-name")
+        network_name = pytestconfig.getoption("--openstack-network-name-arm64")
     else:
         network_name = pytestconfig.getoption("--openstack-network-name-amd64")
     assert network_name, "Please specify the --openstack-network-name(-amd64) command line option"
@@ -165,7 +165,7 @@ def flavor_name_fixture(pytestconfig: pytest.Config, arch: Literal["amd64", "arm
     """Flavor to create testing instances with."""
     flavor_name: str
     if arch == "arm64":
-        flavor_name = pytestconfig.getoption("--openstack-flavor-name")
+        flavor_name = pytestconfig.getoption("--openstack-flavor-name-arm64")
     else:
         flavor_name = pytestconfig.getoption("--openstack-flavor-name-amd64")
     assert flavor_name, "Please specify the --openstack-flavor-name(-amd64) command line option"
@@ -178,13 +178,13 @@ def private_endpoint_configs_fixture(
 ) -> PrivateEndpointConfigs | None:
     """The OpenStack private endpoint configurations."""
     if arch == "arm64":
-        auth_url = pytestconfig.getoption("--openstack-auth-url")
-        password = pytestconfig.getoption("--openstack-password")
-        project_domain_name = pytestconfig.getoption("--openstack-project-domain-name")
-        project_name = pytestconfig.getoption("--openstack-project-name")
-        user_domain_name = pytestconfig.getoption("--openstack-user-domain-name")
-        user_name = pytestconfig.getoption("--openstack-user-name")
-        region_name = pytestconfig.getoption("--openstack-region-name")
+        auth_url = pytestconfig.getoption("--openstack-auth-url-arm64")
+        password = pytestconfig.getoption("--openstack-password-arm64")
+        project_domain_name = pytestconfig.getoption("--openstack-project-domain-name-arm64")
+        project_name = pytestconfig.getoption("--openstack-project-name-arm64")
+        user_domain_name = pytestconfig.getoption("--openstack-user-domain-name-arm64")
+        user_name = pytestconfig.getoption("--openstack-user-name-arm64")
+        region_name = pytestconfig.getoption("--openstack-region-name-arm64")
     else:
         auth_url = pytestconfig.getoption("--openstack-auth-url-amd64")
         password = pytestconfig.getoption("--openstack-password-amd64")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -5,6 +5,7 @@
 import logging
 import secrets
 import string
+import subprocess
 from pathlib import Path
 from typing import AsyncGenerator, Generator, NamedTuple, Optional
 
@@ -94,10 +95,11 @@ async def model_fixture(
 
 
 @pytest_asyncio.fixture(scope="module", name="test_charm")
-async def test_charm_fixture(ops_test: OpsTest, model: Model) -> AsyncGenerator[Application, None]:
+async def test_charm_fixture(model: Model) -> AsyncGenerator[Application, None]:
     """The test charm that becomes active when valid relation data is given."""
-    charm_file = await ops_test.build_charm("tests/integration/data/charm")
-    app = await model.deploy(charm_file)
+    build_cmd = ["charmcraft", "pack", "-p", "tests/integration/data/charm", "-o", "."]
+    subprocess.check_call(build_cmd)
+    app = await model.deploy(f"./test_ubuntu_22.04-{get_juju_arch()}.charm")
     await model.wait_for_idle(apps=[app.name])
 
     yield app

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -233,7 +233,11 @@ def test_id_fixture() -> str:
 
 @pytest_asyncio.fixture(scope="module", name="app")
 async def app_fixture(
-    model: Model, charm_file: str, test_id: str, private_endpoint_configs: PrivateEndpointConfigs
+    model: Model,
+    charm_file: str,
+    test_id: str,
+    private_endpoint_configs: PrivateEndpointConfigs,
+    use_private_endpoint: bool,
 ) -> AsyncGenerator[Application, None]:
     """The deployed application fixture."""
     config = {
@@ -248,10 +252,9 @@ async def app_fixture(
         OPENSTACK_USER_DOMAIN_CONFIG_NAME: private_endpoint_configs["user_domain_name"],
     }
 
-    arch = get_juju_arch()
-    base_machine_constraint = f"arch={arch} cores=4 mem=16G root-disk=20G"
+    base_machine_constraint = f"arch={get_juju_arch()} cores=4 mem=16G root-disk=20G"
     # if local LXD testing model, make the machine of VM type
-    if "test" in model.name and arch == "amd64":
+    if not use_private_endpoint:
         base_machine_constraint += " virt-type=virtual-machine"
     app: Application = await model.deploy(
         charm_file,

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -97,13 +97,14 @@ async def model_fixture(
 
 
 @pytest_asyncio.fixture(scope="module", name="test_charm")
-async def test_charm_fixture(model: Model) -> AsyncGenerator[Application, None]:
+async def test_charm_fixture(model: Model, test_id: str) -> AsyncGenerator[Application, None]:
     """The test charm that becomes active when valid relation data is given."""
     build_cmd = ["charmcraft", "pack", "-p", "tests/integration/data/charm"]
     subprocess.check_call(build_cmd)
     logger.info("Deploying built test charm.")
-    await wait_juju_deploy(f"./test_ubuntu-22.04-{get_juju_arch()}.charm")
-    app = Application(entity_id="test", model=model, connected=False)
+    app_name = f"test-{test_id}"
+    await wait_juju_deploy(f"./test_ubuntu-22.04-{get_juju_arch()}.charm", name=app_name)
+    app = Application(entity_id=app_name, model=model, connected=False)
 
     yield app
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -87,9 +87,9 @@ async def model_fixture(
         yield model
         await model.disconnect()
     else:
-        request.config.option.cloud = None
-        request.config.option.controller = None
-        request.config.option.model = None
+        # Dynamically use ops_test fixture - juju users on private endpoint do not have access to
+        # the controller model and will fail. See issue:
+        # https://github.com/juju/python-libjuju/issues/1064
         ops_test: OpsTest = request.getfixturevalue("ops_test")
         assert ops_test.model is not None
         # Check if private endpoint Juju model is being used. If not, configure proxy.

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -5,7 +5,10 @@
 import logging
 import secrets
 import string
-import subprocess
+
+# subprocess module is used to call juju cli directly due to constraints with private-endpoint
+# models
+import subprocess  # nosec: B404
 from pathlib import Path
 from typing import AsyncGenerator, Generator, NamedTuple, Optional
 
@@ -106,8 +109,10 @@ async def model_fixture(
 @pytest_asyncio.fixture(scope="module", name="test_charm")
 async def test_charm_fixture(model: Model, test_id: str) -> AsyncGenerator[Application, None]:
     """The test charm that becomes active when valid relation data is given."""
-    build_cmd = ["charmcraft", "pack", "-p", "tests/integration/data/charm"]
-    subprocess.check_call(build_cmd)
+    # The predefine inputs here can be trusted
+    subprocess.check_call(  # nosec: B603
+        ["/snap/bin/charmcraft", "pack", "-p", "tests/integration/data/charm"]
+    )
     logger.info("Deploying built test charm.")
     app_name = f"test-{test_id}"
     # the test app does not set status until a proper integration is established, hence wait for

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -41,7 +41,12 @@ from state import (
     REVISION_HISTORY_LIMIT_CONFIG_NAME,
     _get_supported_arch,
 )
-from tests.integration.helpers import get_juju_arch, juju_cli_deploy, wait_for_valid_connection
+from tests.integration.helpers import (
+    get_juju_arch,
+    juju_cli_deploy,
+    juju_cli_remove,
+    wait_for_valid_connection,
+)
 from tests.integration.types import PrivateEndpointConfigs, ProxyConfig, SSHKey
 
 logger = logging.getLogger(__name__)
@@ -125,7 +130,7 @@ async def test_charm_fixture(model: Model, test_id: str) -> AsyncGenerator[Appli
     yield app
 
     logger.info("Cleaning up test charm.")
-    await model.remove_application(app.name)
+    juju_cli_remove(name=app_name)
 
 
 @pytest.fixture(scope="module", name="openstack_clouds_yaml")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -110,7 +110,7 @@ async def test_charm_fixture(model: Model, test_id: str) -> AsyncGenerator[Appli
     subprocess.check_call(build_cmd)
     logger.info("Deploying built test charm.")
     app_name = f"test-{test_id}"
-    juju_cli_deploy(f"./test_ubuntu-22.04-{get_juju_arch()}.charm", name=app_name)
+    await juju_cli_deploy(f"./test_ubuntu-22.04-{get_juju_arch()}.charm", name=app_name, status="unknown")
     app = Application(entity_id=app_name, model=model, connected=False)
 
     yield app

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -5,6 +5,7 @@
 import logging
 import secrets
 import string
+import subprocess
 from pathlib import Path
 from typing import AsyncGenerator, Generator, NamedTuple, Optional
 
@@ -96,15 +97,13 @@ async def model_fixture(
 
 
 @pytest_asyncio.fixture(scope="module", name="test_charm")
-async def test_charm_fixture(
-    model: Model, test_id: str, ops_test: OpsTest
-) -> AsyncGenerator[Application, None]:
+async def test_charm_fixture(model: Model, test_id: str) -> AsyncGenerator[Application, None]:
     """The test charm that becomes active when valid relation data is given."""
-    logger.info("Building charm.")
-    test_charm = await ops_test.build_charm("test/integration/data/charm")
+    build_cmd = ["charmcraft", "pack", "-p", "tests/integration/data/charm"]
+    subprocess.check_call(build_cmd)
     logger.info("Deploying built test charm.")
     app_name = f"test-{test_id}"
-    await wait_juju_deploy(test_charm, name=app_name)
+    await wait_juju_deploy(f"./test_ubuntu-22.04-{get_juju_arch()}.charm", name=app_name)
     app = Application(entity_id=app_name, model=model, connected=False)
 
     yield app

--- a/tests/integration/data/charm/charmcraft.yaml
+++ b/tests/integration/data/charm/charmcraft.yaml
@@ -8,7 +8,7 @@
 # The charm package name, no spaces (required)
 # See https://juju.is/docs/sdk/naming#heading--naming-charms for guidance.
 name: test
-title: Test charm for github runner image builder
+title: test
 summary: Test charm for github runner image builder
 description: |
   Test charm for github runner image builder.
@@ -26,12 +26,20 @@ bases:
       channel: "22.04"
       architectures:
       - amd64
-      - arm64
     run-on:
     - name: "ubuntu"
       channel: "22.04"
       architectures:
       - amd64
+  - build-on:
+    - name: "ubuntu"
+      channel: "22.04"
+      architectures:
+      - arm64
+    run-on:
+    - name: "ubuntu"
+      channel: "22.04"
+      architectures:
       - arm64
 
 config:

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -195,7 +195,7 @@ async def juju_cli_deploy(charm: Path | str, name: str, status: str):
         ["/snap/bin/juju", "deploy", str(charm), name], timeout=5 * 60, encoding="utf-8"
     )
 
-    await wait_for(functools.partial(is_expected_app_status, name, status))
+    await wait_for(functools.partial(is_expected_app_status, name, status), timeout=10 * 60)
 
 
 def is_expected_app_status(name: str, status: str):
@@ -221,3 +221,15 @@ def is_expected_app_status(name: str, status: str):
         return status_output["applications"][name]["application-status"]["current"] == status
     except KeyError:
         return False
+
+
+def juju_cli_remove(name: str):
+    """Deploy juju via CLI and wait for condition.
+
+    Args:
+        name: The name of the application to deploy as.
+    """
+    # The Juju we are deploying a charm with trusted fixture values.
+    subprocess.check_call(  # nosec: B603
+        ["/snap/bin/juju", "remove-application", name], timeout=5 * 60, encoding="utf-8"
+    )

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -8,7 +8,10 @@ import inspect
 import json
 import logging
 import platform
-import subprocess
+
+# subprocess module is used to call juju cli directly due to constraints with private-endpoint
+# models
+import subprocess  # nosec: B404
 import time
 from pathlib import Path
 from typing import Awaitable, Callable, ParamSpec, TypeVar, cast
@@ -187,7 +190,8 @@ async def juju_cli_deploy(charm: Path | str, name: str, status: str):
         name: The name of the application to deploy as.
         status: The desired status of the application to wait for.
     """
-    output = subprocess.check_output(
+    # The Juju we are deploying a charm with trusted fixture values.
+    output = subprocess.check_output(  # nosec: B603
         ["/snap/bin/juju", "deploy", str(charm), name], timeout=5 * 60, encoding="utf-8"
     )
     assert "Deploying" in output, f"Invalid deploy output, {output}"
@@ -207,7 +211,8 @@ def is_expected_app_status(name: str, status: str):
         Whether the application status is matching the desired status.
     """
     status_output = json.loads(
-        subprocess.check_output(
+        # the predefined inputs can be trusted
+        subprocess.check_output(  # nosec: B603
             ["/snap/bin/juju", "status", "--format", "json"],
             timeout=5 * 60,
             encoding="utf-8",

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -4,7 +4,6 @@
 """Helper utilities for integration tests."""
 
 import inspect
-import json
 import logging
 import platform
 import subprocess
@@ -178,7 +177,7 @@ def get_juju_arch() -> str:
     return "amd64"
 
 
-async def wait_juju_deploy(charm: Path | str, name: str):
+def juju_cli_deploy(charm: Path | str, name: str):
     """Deploy juju via CLI and wait for condition.
 
     Args:
@@ -189,21 +188,3 @@ async def wait_juju_deploy(charm: Path | str, name: str):
         ["/snap/bin/juju", "deploy", str(charm), name], timeout=5 * 60, encoding="utf-8"
     )
     logger.info("juju deploy output: %s", output)
-
-    def application_status_active():
-        """Wait for application status to become active.
-
-        Returns:
-            Whether the application status is active.
-        """
-        status_output = json.loads(
-            subprocess.check_output(
-                ["/snap/bin/juju", "status", "--format", "json"],
-                timeout=5 * 60,
-                encoding="utf-8",
-            )
-        )
-        logger.info("Status json out: %s", status_output["applications"][name])
-        return status_output["applications"][name]["application-status"]["current"] == "active"
-
-    await wait_for(application_status_active)

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -5,7 +5,6 @@
 
 import inspect
 import logging
-import platform
 import time
 from pathlib import Path
 from typing import Awaitable, Callable, ParamSpec, TypeVar, cast
@@ -16,7 +15,6 @@ from openstack.compute.v2.server import Server
 from openstack.connection import Connection
 from paramiko.ssh_exception import NoValidConnectionsError, SSHException
 
-import state
 from tests.integration.types import ProxyConfig
 
 logger = logging.getLogger(__name__)
@@ -158,19 +156,3 @@ async def wait_for(
         if result := func():
             return cast(R, result)
     raise TimeoutError()
-
-
-def get_juju_arch() -> str:
-    """Get juju compatible architecture.
-
-    Returns:
-        The juju compatible compute architecture.
-    """
-    arch = platform.machine()
-    match arch:
-        case arch if arch in state.ARCHITECTURES_ARM64:
-            return "arm64"
-        case arch if arch in state.ARCHITECTURES_X86:
-            return "amd64"
-    logger.warning("No matching architecture found, defaulting to amd64.")
-    return "amd64"

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -191,11 +191,9 @@ async def juju_cli_deploy(charm: Path | str, name: str, status: str):
         status: The desired status of the application to wait for.
     """
     # The Juju we are deploying a charm with trusted fixture values.
-    output = subprocess.check_output(  # nosec: B603
+    subprocess.check_call(  # nosec: B603
         ["/snap/bin/juju", "deploy", str(charm), name], timeout=5 * 60, encoding="utf-8"
     )
-    assert "Deploying" in output, f"Invalid deploy output, {output}"
-    logger.info("juju deploy output: %s", output)
 
     await wait_for(functools.partial(is_expected_app_status, name, status))
 

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -203,7 +203,7 @@ async def wait_juju_deploy(charm: Path | str, name: str):
                 encoding="utf-8",
             )
         )
-        logger.info("Status json out: %s", status_output)
+        logger.info("Status json out: %s", status_output["applications"][name])
         return status_output["applications"][name]["application-status"]["current"] == "active"
 
     await wait_for(application_status_active)

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -178,14 +178,15 @@ def get_juju_arch() -> str:
     return "amd64"
 
 
-async def wait_juju_deploy(charm: Path | str):
+async def wait_juju_deploy(charm: Path | str, name: str):
     """Deploy juju via CLI and wait for condition.
 
     Args:
         charm: The path to charm to deploy.
+        name: The name of the application to deploy as.
     """
     output = subprocess.check_output(
-        ["/snap/bin/juju", "deploy", str(charm)], timeout=5 * 60, encoding="utf-8"
+        ["/snap/bin/juju", "deploy", str(charm), name], timeout=5 * 60, encoding="utf-8"
     )
     logger.info("juju deploy output: %s", output)
     await wait_for(
@@ -193,6 +194,6 @@ async def wait_juju_deploy(charm: Path | str):
             subprocess.check_output(
                 ["/snap/bin/juju", "status", "--format", "json"], timeout=5 * 60, encoding="utf-8"
             )
-        )["applications"]["application-status"]["current"]
+        )["applications"][name]["application-status"]["current"]
         == "active"
     )

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -4,10 +4,8 @@
 """Helper utilities for integration tests."""
 
 import inspect
-import json
 import logging
 import platform
-import subprocess
 import time
 from pathlib import Path
 from typing import Awaitable, Callable, ParamSpec, TypeVar, cast
@@ -176,23 +174,3 @@ def get_juju_arch() -> str:
             return "amd64"
     logger.warning("No matching architecture found, defaulting to amd64.")
     return "amd64"
-
-
-async def wait_juju_deploy(charm: Path | str):
-    """Deploy juju via CLI and wait for condition.
-
-    Args:
-        charm: The path to charm to deploy.
-    """
-    output = subprocess.check_output(
-        ["/snap/bin/juju", "deploy", str(charm)], timeout=5 * 60, encoding="utf-8"
-    )
-    logger.info("juju deploy output: %s", output)
-    await wait_for(
-        lambda: json.loads(
-            subprocess.check_output(
-                ["/snap/bin/juju", "status", "--format", "json"], timeout=5 * 60, encoding="utf-8"
-            )
-        )["applications"]["application-status"]["current"]
-        == "active"
-    )

--- a/tests/integration/requirements.txt
+++ b/tests/integration/requirements.txt
@@ -1,2 +1,3 @@
 fabric
 types-paramiko
+nest_asyncio

--- a/tests/integration/setup_private_endpoint.sh
+++ b/tests/integration/setup_private_endpoint.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash --login
+
+# These need to be set as environment variables in GitHub secrets.
+MISSING_ENV="false"
+if [ -z ${VAULT_APPROLE_ROLE_ID+x} ]; then
+    echo "VAULT_APPROLE_ROLE_ID needs to be set"
+    MISSING_ENV="true"
+fi
+if [ -z ${VAULT_APPROLE_SECRET_ID+x} ]; then
+    echo "VAULT_APPROLE_SECRET_ID needs to be set"
+    MISSING_ENV="true"
+fi
+if [ -z ${JUJU_CONTROLLER+x} ]; then
+    echo "JUJU_CONTROLLER needs to be set"
+    MISSING_ENV="true"
+fi
+if [ -z ${JUJU_MODEL+x} ]; then
+    echo "JUJU_MODEL needs to be set"
+    MISSING_ENV="true"
+fi
+if [ -z ${PRODSTACK+x} ]; then
+    echo "PRODSTACK needs to be set"
+    MISSING_ENV="true"
+fi
+if [ -z ${VAULT_ADDR+x} ]; then
+    echo "VAULT_ADDR needs to be set"
+    MISSING_ENV="true"
+fi
+
+if [ ${MISSING_ENV} = "true" ]; then
+    exit 1
+fi
+
+export VAULT_SECRET_PATH_ROLE=secret/${PRODSTACK}/roles/${JUJU_MODEL##*/}
+export VAULT_SECRET_PATH_COMMON=secret/${PRODSTACK}/juju/common
+
+# Ensure we remove any juju config on any kind of exit
+trap "[ -d "${HOME}/.local/share/juju" ] && rm -rf ${HOME}/.local/share/juju/*" EXIT
+
+sudo snap install juju --channel=3.1/stable
+sudo snap install vault
+
+function vault_auth(){
+    if [ -z "${VAULT_TOKEN}" ] || ([ -n "${VAULT_TOKEN}" ] && ! vault token lookup > /dev/null 2>&1 ); then
+        if [ -n "$TERM" -a "$TERM" != "unknown" ]; then
+            echo "Authenticating to vault"
+        fi
+        VAULT_TOKEN=$(vault write -f -field=token auth/approle/login role_id=${VAULT_APPROLE_ROLE_ID} secret_id=${VAULT_APPROLE_SECRET_ID})
+        export VAULT_TOKEN
+    fi
+}
+
+function load_juju_controller_config(){
+    vault_auth
+    vault read -field=controller_config "${VAULT_SECRET_PATH_COMMON}"/controllers/"${JUJU_CONTROLLER}" | base64 -d - > "${HOME}/.local/share/juju/controllers.yaml"
+}
+
+function load_juju_account_config(){
+    vault_auth
+    USERNAME=$(vault read -field=username "${VAULT_SECRET_PATH_ROLE}"/juju) || return
+    PASSWORD=$(vault read -field=password "${VAULT_SECRET_PATH_ROLE}"/juju) || return
+    # Watch out for tabs vs spaces when editing the below. First character in each line is a tab
+    # which is ignored by the heredoc, to prevent script indentation affecting the written file.
+    cat <<- EOF > "${HOME}/.local/share/juju/accounts.yaml"
+	controllers:
+	    ${JUJU_CONTROLLER?}:
+	        user: ${USERNAME}
+	        password: ${PASSWORD}
+	EOF
+}
+
+# Remove any existing juju config before pulling from Vault
+[ -d "${HOME}/.local/share/juju" ] && rm -rf ${HOME}/.local/share/juju/*
+mkdir -p ${HOME}/.local/share/juju
+
+echo "Pulling Juju controller config from Vault"
+load_juju_controller_config
+echo "Pulling Juju account config from Vault"
+load_juju_account_config
+
+juju status

--- a/tests/integration/setup_private_endpoint.sh
+++ b/tests/integration/setup_private_endpoint.sh
@@ -1,5 +1,8 @@
 #!/bin/bash --login
 
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 # These need to be set as environment variables in GitHub secrets.
 MISSING_ENV="false"
 if [ -z ${VAULT_APPROLE_ROLE_ID+x} ]; then

--- a/tests/integration/setup_private_endpoint.sh
+++ b/tests/integration/setup_private_endpoint.sh
@@ -89,6 +89,10 @@ function load_juju_account_config(){
 	EOF
 }
 
+function switch_juju_model(){
+    juju switch $(juju models --format json | jq -r '.models[0].name')
+}
+
 # Remove any existing juju config before pulling from Vault
 [ -d "${HOME}/.local/share/juju" ] && rm -rf "${HOME}"/.local/share/juju/*
 mkdir -p "${HOME}"/.local/share/juju
@@ -97,5 +101,7 @@ echo "Pulling Juju controller config from Vault"
 load_juju_controller_config
 echo "Pulling Juju account config from Vault"
 load_juju_account_config
+echo "Switching to model"
+switch_juju_model
 
 juju status

--- a/tests/integration/setup_private_endpoint.sh
+++ b/tests/integration/setup_private_endpoint.sh
@@ -43,8 +43,8 @@ function remove_juju_config(){
     fi
 }
 
-# Ensure we remove any juju config on any kind of exit
-trap remove_juju_config EXIT
+# Ensure we remove any juju config on error
+trap remove_juju_config ERR
 
 sudo snap install juju --channel=3.1/stable
 sudo snap install vault
@@ -93,7 +93,7 @@ function switch_juju_model(){
     # cannot switch if these environment variables are set
     # by default, the model is not selected and `juju status` will fail
     unset JUJU_CONTROLLER JUJU_MODEL
-    juju switch $(juju models --format json | jq -r '.models[0].name')
+    juju switch "$(juju models --format json | jq -r '.models[0].name')"
 }
 
 # Remove any existing juju config before pulling from Vault

--- a/tests/integration/setup_private_endpoint.sh
+++ b/tests/integration/setup_private_endpoint.sh
@@ -90,6 +90,9 @@ function load_juju_account_config(){
 }
 
 function switch_juju_model(){
+    # cannot switch if these environment variables are set
+    # by default, the model is not selected and `juju status` will fail
+    unset JUJU_CONTROLLER JUJU_MODEL
     juju switch $(juju models --format json | jq -r '.models[0].name')
 }
 

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -25,37 +25,37 @@ from tests.integration.types import ProxyConfig
 logger = logging.getLogger(__name__)
 
 
-@pytest.mark.asyncio
-async def test_build_image(app: Application, openstack_connection: Connection):
-    """
-    arrange: A deployed active charm.
-    act: When openstack images are listed.
-    assert: An image is built successfully.
-    """
-    dispatch_time = datetime.now(tz=timezone.utc)
-    config: dict = await app.get_config()
-    image_base = config[BASE_IMAGE_CONFIG_NAME]["value"]
+# @pytest.mark.asyncio
+# async def test_build_image(app: Application, openstack_connection: Connection):
+#     """
+#     arrange: A deployed active charm.
+#     act: When openstack images are listed.
+#     assert: An image is built successfully.
+#     """
+#     dispatch_time = datetime.now(tz=timezone.utc)
+#     config: dict = await app.get_config()
+#     image_base = config[BASE_IMAGE_CONFIG_NAME]["value"]
 
-    def image_created_from_dispatch() -> bool:
-        """Return whether there is an image created after dispatch has been called.
+#     def image_created_from_dispatch() -> bool:
+#         """Return whether there is an image created after dispatch has been called.
 
-        Returns:
-            Whether there exists an image that has been created after dispatch time.
-        """
-        image_name = IMAGE_NAME_TMPL.format(
-            IMAGE_BASE=image_base, APP_NAME=app.name, ARCH=_get_supported_arch().value
-        )
-        images: list[Image] = openstack_connection.search_images(image_name)
-        logger.info("Image name: %s, Images: %s", image_name, images)
-        # split logs, the image log is long and gets cut off.
-        logger.info("Dispatch time: %s", dispatch_time)
-        return any(
-            datetime.strptime(image.created_at, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
-            >= dispatch_time
-            for image in images
-        )
+#         Returns:
+#             Whether there exists an image that has been created after dispatch time.
+#         """
+#         image_name = IMAGE_NAME_TMPL.format(
+#             IMAGE_BASE=image_base, APP_NAME=app.name, ARCH=_get_supported_arch().value
+#         )
+#         images: list[Image] = openstack_connection.search_images(image_name)
+#         logger.info("Image name: %s, Images: %s", image_name, images)
+#         # split logs, the image log is long and gets cut off.
+#         logger.info("Dispatch time: %s", dispatch_time)
+#         return any(
+#             datetime.strptime(image.created_at, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
+#             >= dispatch_time
+#             for image in images
+#         )
 
-    await wait_for(image_created_from_dispatch, check_interval=30, timeout=60 * 30)
+#     await wait_for(image_created_from_dispatch, check_interval=30, timeout=60 * 30)
 
 
 @pytest.mark.asyncio
@@ -67,7 +67,7 @@ async def test_image_relation(model: Model, app: Application, test_charm: Applic
     """
     await app.relate("image", f"{test_charm.name}:image")
     await model.wait_for_idle(
-        apps=[app.name, test_charm.name], wait_for_active=True, timeout=5 * 60
+        apps=[app.name, test_charm.name], wait_for_active=True, timeout=30 * 60
     )
 
 

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -65,11 +65,6 @@ async def test_image_relation(app: Application, test_charm: Application):
     act: When the relation is joined.
     assert: The test charm becomes active due to proper relation data.
     """
-    # Use CLI call since Juju model, due to ARM64 private endpoint constraints, has been imported
-    # dynamically (see conftest.py def model_fixture). This causes the model object to not work
-    # as expected (the REPL also has a different behavior) and throw KeyError or websocket
-    # disconnect error.
-    # we are using trusted input here.
     model: Model = app.model
     await model.integrate(app.name, test_charm.name)
     await model.wait_for_idle([app.name, test_charm.name], wait_for_active=True)

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -46,9 +46,9 @@ async def test_build_image(app: Application, openstack_connection: Connection):
             IMAGE_BASE=image_base, APP_NAME=app.name, ARCH=_get_supported_arch().value
         )
         images: list[Image] = openstack_connection.search_images(image_name)
-        logger.info(
-            "Image name: %s, Images: %s, dispatch time: %s", image_name, images, dispatch_time
-        )
+        logger.info("Image name: %s, Images: %s", image_name, images)
+        # split logs, the image log is long and gets cut off.
+        logger.info("Dispatch time: %s", dispatch_time)
         return any(
             datetime.strptime(image.created_at, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
             >= dispatch_time

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -25,37 +25,37 @@ from tests.integration.types import ProxyConfig
 logger = logging.getLogger(__name__)
 
 
-# @pytest.mark.asyncio
-# async def test_build_image(app: Application, openstack_connection: Connection):
-#     """
-#     arrange: A deployed active charm.
-#     act: When openstack images are listed.
-#     assert: An image is built successfully.
-#     """
-#     dispatch_time = datetime.now(tz=timezone.utc)
-#     config: dict = await app.get_config()
-#     image_base = config[BASE_IMAGE_CONFIG_NAME]["value"]
+@pytest.mark.asyncio
+async def test_build_image(app: Application, openstack_connection: Connection):
+    """
+    arrange: A deployed active charm.
+    act: When openstack images are listed.
+    assert: An image is built successfully.
+    """
+    dispatch_time = datetime.now(tz=timezone.utc)
+    config: dict = await app.get_config()
+    image_base = config[BASE_IMAGE_CONFIG_NAME]["value"]
 
-#     def image_created_from_dispatch() -> bool:
-#         """Return whether there is an image created after dispatch has been called.
+    def image_created_from_dispatch() -> bool:
+        """Return whether there is an image created after dispatch has been called.
 
-#         Returns:
-#             Whether there exists an image that has been created after dispatch time.
-#         """
-#         image_name = IMAGE_NAME_TMPL.format(
-#             IMAGE_BASE=image_base, APP_NAME=app.name, ARCH=_get_supported_arch().value
-#         )
-#         images: list[Image] = openstack_connection.search_images(image_name)
-#         logger.info("Image name: %s, Images: %s", image_name, images)
-#         # split logs, the image log is long and gets cut off.
-#         logger.info("Dispatch time: %s", dispatch_time)
-#         return any(
-#             datetime.strptime(image.created_at, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
-#             >= dispatch_time
-#             for image in images
-#         )
+        Returns:
+            Whether there exists an image that has been created after dispatch time.
+        """
+        image_name = IMAGE_NAME_TMPL.format(
+            IMAGE_BASE=image_base, APP_NAME=app.name, ARCH=_get_supported_arch().value
+        )
+        images: list[Image] = openstack_connection.search_images(image_name)
+        logger.info("Image name: %s, Images: %s", image_name, images)
+        # split logs, the image log is long and gets cut off.
+        logger.info("Dispatch time: %s", dispatch_time)
+        return any(
+            datetime.strptime(image.created_at, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
+            >= dispatch_time
+            for image in images
+        )
 
-#     await wait_for(image_created_from_dispatch, check_interval=30, timeout=60 * 30)
+    await wait_for(image_created_from_dispatch, check_interval=30, timeout=60 * 30)
 
 
 @pytest.mark.asyncio
@@ -67,7 +67,7 @@ async def test_image_relation(model: Model, app: Application, test_charm: Applic
     """
     await app.relate("image", f"{test_charm.name}:image")
     await model.wait_for_idle(
-        apps=[app.name, test_charm.name], wait_for_active=True, timeout=30 * 60
+        apps=[app.name, test_charm.name], wait_for_active=True, timeout=5 * 60
     )
 
 

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -5,7 +5,9 @@
 
 """Integration testing module."""
 
+import functools
 import logging
+import subprocess
 from datetime import datetime, timezone
 from typing import NamedTuple
 
@@ -13,13 +15,12 @@ import pytest
 from fabric.connection import Connection as SSHConnection
 from fabric.runners import Result
 from juju.application import Application
-from juju.model import Model
 from openstack.connection import Connection
 from openstack.image.v2.image import Image
 
 from builder import IMAGE_NAME_TMPL
 from state import BASE_IMAGE_CONFIG_NAME, _get_supported_arch
-from tests.integration.helpers import wait_for
+from tests.integration.helpers import is_expected_app_status, wait_for
 from tests.integration.types import ProxyConfig
 
 logger = logging.getLogger(__name__)
@@ -59,16 +60,20 @@ async def test_build_image(app: Application, openstack_connection: Connection):
 
 
 @pytest.mark.asyncio
-async def test_image_relation(model: Model, app: Application, test_charm: Application):
+async def test_image_relation(app: Application, test_charm: Application):
     """
     arrange: An active charm and a test charm that becomes active when valid relation data is set.
     act: When the relation is joined.
     assert: The test charm becomes active due to proper relation data.
     """
-    await model.integrate(f"{app.name}:image", f"{test_charm.name}:image")
-    await model.wait_for_idle(
-        apps=[app.name, test_charm.name], wait_for_active=True, timeout=5 * 60
+    # Use CLI call since Juju model, due to ARM64 private endpoint constraints, has been imported
+    # dynamically (see conftest.py def model_fixture). This causes the model object to not work
+    # as expected (the REPL also has a different behavior) and throw KeyError or websocket
+    # disconnect error.
+    subprocess.check_call(
+        ["/snap/bin/juju", "integrate", app.name, test_charm.name], timeout=5 * 60
     )
+    await wait_for(functools.partial(is_expected_app_status, test_charm.name, "active"))
 
 
 class Commands(NamedTuple):

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -7,7 +7,10 @@
 
 import functools
 import logging
-import subprocess
+
+# subprocess module is used to call juju cli directly due to constraints with private-endpoint
+# models
+import subprocess  # nosec: B404
 from datetime import datetime, timezone
 from typing import NamedTuple
 
@@ -70,7 +73,8 @@ async def test_image_relation(app: Application, test_charm: Application):
     # dynamically (see conftest.py def model_fixture). This causes the model object to not work
     # as expected (the REPL also has a different behavior) and throw KeyError or websocket
     # disconnect error.
-    subprocess.check_call(
+    # we are using trusted input here.
+    subprocess.check_call(  # nosec: B603
         ["/snap/bin/juju", "integrate", app.name, test_charm.name], timeout=5 * 60
     )
     await wait_for(functools.partial(is_expected_app_status, test_charm.name, "active"))

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -65,7 +65,7 @@ async def test_image_relation(model: Model, app: Application, test_charm: Applic
     act: When the relation is joined.
     assert: The test charm becomes active due to proper relation data.
     """
-    await app.relate("image", f"{test_charm.name}:image")
+    await model.integrate(f"{app.name}:image", f"{test_charm.name}:image")
     await model.wait_for_idle(
         apps=[app.name, test_charm.name], wait_for_active=True, timeout=5 * 60
     )

--- a/tests/integration/types.py
+++ b/tests/integration/types.py
@@ -39,6 +39,7 @@ class PrivateEndpointConfigs(typing.TypedDict):
     """The Private endpoint configuration values.
 
     Attributes:
+        arch: The architecture the test is running on.
         auth_url: OpenStack uthentication URL (Keystone).
         password: OpenStack password.
         project_domain_name: OpenStack project domain to use.
@@ -48,6 +49,7 @@ class PrivateEndpointConfigs(typing.TypedDict):
         region_name: OpenStack deployment region.
     """
 
+    arch: typing.Literal["amd64", "arm64"]
     auth_url: str
     password: str
     project_domain_name: str


### PR DESCRIPTION
Applicable spec: N/A

### Overview

<!-- A high level overview of the change -->

- Changes tests to use private endpoints

### Rationale

<!-- The reason the change is needed -->

- Due to constraints of ARM64 nested virtualization, if we deploy ARM64 image builder charm on top of LXD VM (OpenStack runner VM -> LXD VM = 2 nested virt layers), the KVM is not available and the image bulid will fail.

### Juju Events Changes

None.

### Module Changes

None.

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
