### PR TITLE
feat: external builder

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -42,6 +42,10 @@ bases:
         architectures:
           - amd64
 
+actions:
+  run:
+    description: Trigger an image builder run immediately.
+
 config:
   options:
     app-channel:

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -20,6 +20,20 @@ links:
   website: https://charmhub.io/github-runner-image-builder
 
 type: charm
+
+parts:
+  charm:
+    build-snaps:
+      - rustup
+    build-packages:
+      - libffi-dev  # for cffi
+      - libssl-dev  # for cryptography
+      - rust-all  # for cryptography
+      - pkg-config # for cryptography
+    override-build: |
+      rustup default stable
+      craftctl default
+
 bases:
   - build-on:
       - name: ubuntu
@@ -65,7 +79,7 @@ config:
       description: |
         The interval in hours between each scheduled image builds.
     experimental-external-build:
-      type: bool
+      type: boolean
       default: false
       description: |
         (Experimental) Whether to use external OpenStack builder VM to build a snapshot image.

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -60,6 +60,23 @@ config:
       default: 6
       description: |
         The interval in hours between each scheduled image builds.
+    experimental-external-build:
+      type: bool
+      default: false
+      description: |
+        (Experimental) Whether to use external OpenStack builder VM to build a snapshot image.
+    experimental-external-build-flavor:
+      type: string
+      default: ""
+      description: |
+        (Experimental) The flavor to use when launching a builder VM machine. Will default to
+        minimum matching flavor: 2 vCPU, 8G Memory, 20G Disk.
+    experimental-external-build-network:
+      type: string
+      default: ""
+      description: |
+        (Experimental) The network to launch the builder VM machine on. Will default to whatever
+        network with accessible subnet is available.
     openstack-auth-url:
       type: string
       default: ""

--- a/src-docs/builder.py.md
+++ b/src-docs/builder.py.md
@@ -112,7 +112,7 @@ Run a build immediately.
 
 ---
 
-<a href="../src/builder.py#L222"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/builder.py#L223"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `get_latest_image`
 
@@ -144,7 +144,7 @@ Fetch the latest image build ID.
 
 ---
 
-<a href="../src/builder.py#L258"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/builder.py#L259"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `upgrade_app`
 

--- a/src-docs/builder.py.md
+++ b/src-docs/builder.py.md
@@ -13,7 +13,7 @@ Module for interacting with qemu image builder.
 
 ---
 
-<a href="../src/builder.py#L49"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/builder.py#L48"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `initialize`
 
@@ -38,7 +38,7 @@ Configure the host machine to build images.
 
 ---
 
-<a href="../src/builder.py#L111"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/builder.py#L116"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `install_clouds_yaml`
 
@@ -57,12 +57,12 @@ Install clouds.yaml for Openstack used by the image builder.
 
 ---
 
-<a href="../src/builder.py#L124"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/builder.py#L129"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `configure_cron`
 
 ```python
-configure_cron(run_config: BuilderRunConfig, interval: int) → bool
+configure_cron(unit_name: str, interval: int) → bool
 ```
 
 Configure cron to run builder. 
@@ -71,7 +71,7 @@ Configure cron to run builder.
 
 **Args:**
  
- - <b>`run_config`</b>:  The configuration required to run builder. 
+ - <b>`unit_name`</b>:  The charm unit name to run cronjob dispatch hook. 
  - <b>`interval`</b>:  Number of hours in between image build runs. 
 
 
@@ -82,12 +82,12 @@ Configure cron to run builder.
 
 ---
 
-<a href="../src/builder.py#L186"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/builder.py#L172"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `run`
 
 ```python
-run(config: BuilderRunConfig) → None
+run(config: BuilderRunConfig) → str
 ```
 
 Run a build immediately. 
@@ -105,9 +105,14 @@ Run a build immediately.
  - <b>`BuilderRunError`</b>:  if there was an error while launching the subprocess. 
 
 
+
+**Returns:**
+ The built image id. 
+
+
 ---
 
-<a href="../src/builder.py#L244"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/builder.py#L222"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `get_latest_image`
 
@@ -139,7 +144,7 @@ Fetch the latest image build ID.
 
 ---
 
-<a href="../src/builder.py#L280"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/builder.py#L258"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `upgrade_app`
 

--- a/src-docs/charm.py.md
+++ b/src-docs/charm.py.md
@@ -5,51 +5,6 @@
 # <kbd>module</kbd> `charm.py`
 Entrypoint for GithubRunnerImageBuilder charm. 
 
-**Global Variables**
----------------
-- **BUILD_SUCCESS_EVENT_NAME**
-- **BUILD_FAIL_EVENT_NAME**
-- **OPENSTACK_IMAGE_ID_ENV**
-
-
----
-
-## <kbd>class</kbd> `BuildEvents`
-Represents events triggered by image builder callback. 
-
-
-
-**Attributes:**
- 
- - <b>`build_success`</b>:  Represents a successful image build event. 
- - <b>`build_failed`</b>:  Represents a failed image build event. 
-
-
----
-
-#### <kbd>property</kbd> model
-
-Shortcut for more simple access the model. 
-
-
-
-
----
-
-## <kbd>class</kbd> `BuildFailedEvent`
-Represents a failed image build event. 
-
-
-
-
-
----
-
-## <kbd>class</kbd> `BuildSuccessEvent`
-Represents a successful image build event. 
-
-
-
 
 
 ---
@@ -57,13 +12,7 @@ Represents a successful image build event.
 ## <kbd>class</kbd> `GithubRunnerImageBuilderCharm`
 Charm GitHubRunner image builder application. 
 
-
-
-**Attributes:**
- 
- - <b>`on`</b>:  Represents custom events managed by cron. 
-
-<a href="../src/charm.py#L57"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm.py#L25"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `__init__`
 
@@ -117,27 +66,5 @@ Shortcut for more simple access the model.
 Unit that this execution is responsible for. 
 
 
----
-
-#### <kbd>handler</kbd> on
-
-
----
-
-<a href="../src/charm.py#L155"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
-
-### <kbd>function</kbd> `update_status`
-
-```python
-update_status(status: StatusBase) → None
-```
-
-Update the charm status. 
-
-
-
-**Args:**
- 
- - <b>`status`</b>:  The desired status instance. 
 
 

--- a/src-docs/charm.py.md
+++ b/src-docs/charm.py.md
@@ -67,4 +67,22 @@ Unit that this execution is responsible for.
 
 
 
+---
+
+<a href="../src/charm.py#L78"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+### <kbd>function</kbd> `update_status`
+
+```python
+update_status(status: StatusBase) → None
+```
+
+Update the charm status. 
+
+
+
+**Args:**
+ 
+ - <b>`status`</b>:  The desired status instance. 
+
 

--- a/src-docs/state.py.md
+++ b/src-docs/state.py.md
@@ -137,15 +137,17 @@ The image builder setup config.
 **Attributes:**
  
  - <b>`channel`</b>:  The application installation channel. 
+ - <b>`external_build`</b>:  Whether the image builder should run in external build mode. 
  - <b>`interval`</b>:  The interval in hours between each scheduled image builds. 
  - <b>`run_config`</b>:  The configuration required to build the image. 
+ - <b>`unit_name`</b>:  The charm unit name in which the builder is running on. 
 
 
 
 
 ---
 
-<a href="../src/state.py#L463"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/state.py#L466"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `from_charm`
 
@@ -308,7 +310,7 @@ Configurations for external builder VMs.
 ### <kbd>classmethod</kbd> `from_charm`
 
 ```python
-from_charm(charm: CharmBase)
+from_charm(charm: CharmBase) → ExternalBuildConfig
 ```
 
 Initialize build configuration from current charm instance. 

--- a/src-docs/state.py.md
+++ b/src-docs/state.py.md
@@ -14,6 +14,9 @@ Module for interacting with charm state and configurations.
 - **APP_CHANNEL_CONFIG_NAME**
 - **BASE_IMAGE_CONFIG_NAME**
 - **BUILD_INTERVAL_CONFIG_NAME**
+- **EXTERNAL_BUILD_CONFIG_NAME**
+- **EXTERNAL_BUILD_FLAVOR_CONFIG_NAME**
+- **EXTERNAL_BUILD_NETWORK_CONFIG_NAME**
 - **OPENSTACK_AUTH_URL_CONFIG_NAME**
 - **OPENSTACK_PASSWORD_CONFIG_NAME**
 - **OPENSTACK_PROJECT_DOMAIN_CONFIG_NAME**
@@ -61,7 +64,7 @@ The ubuntu OS base image to build and deploy runners on.
 ## <kbd>class</kbd> `BuildConfigInvalidError`
 Raised when charm config related to image build config is invalid. 
 
-<a href="../src/state.py#L47"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/state.py#L50"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `__init__`
 
@@ -104,7 +107,7 @@ This is managed by the application's git tag and versioning tag in pyproject.tom
 ## <kbd>class</kbd> `BuilderAppChannelInvalidError`
 Represents invalid builder app channel configuration. 
 
-<a href="../src/state.py#L47"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/state.py#L50"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `__init__`
 
@@ -134,15 +137,15 @@ The image builder setup config.
 **Attributes:**
  
  - <b>`channel`</b>:  The application installation channel. 
- - <b>`run_config`</b>:  The configuration required to build the image. 
  - <b>`interval`</b>:  The interval in hours between each scheduled image builds. 
+ - <b>`run_config`</b>:  The configuration required to build the image. 
 
 
 
 
 ---
 
-<a href="../src/state.py#L415"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/state.py#L463"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `from_charm`
 
@@ -183,6 +186,7 @@ Configurations for running builder periodically.
  - <b>`base`</b>:  Ubuntu OS image to build from. 
  - <b>`cloud_config`</b>:  The Openstack clouds.yaml passed as charm config. 
  - <b>`cloud_name`</b>:  The Openstack cloud name to connect to from clouds.yaml. 
+ - <b>`external_build_config`</b>:  The external builder configuration values. 
  - <b>`num_revisions`</b>:  Number of images to keep before deletion. 
  - <b>`runner_version`</b>:  The GitHub runner version to embed in the image. Latest version if empty. 
  - <b>`callback_script`</b>:  Path to callback script. 
@@ -198,7 +202,7 @@ The cloud name from cloud_config.
 
 ---
 
-<a href="../src/state.py#L199"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/state.py#L239"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `from_charm`
 
@@ -231,7 +235,7 @@ Initialize build state from current charm instance.
 ## <kbd>class</kbd> `BuilderSetupConfigInvalidError`
 Raised when charm config related to image build setup config is invalid. 
 
-<a href="../src/state.py#L47"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/state.py#L50"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `__init__`
 
@@ -262,7 +266,7 @@ Raised when charm config is invalid.
  
  - <b>`msg`</b>:  Explanation of the error. 
 
-<a href="../src/state.py#L47"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/state.py#L50"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `__init__`
 
@@ -280,6 +284,45 @@ Initialize a new instance of the CharmConfigInvalidError exception.
 
 
 
+
+
+---
+
+## <kbd>class</kbd> `ExternalBuildConfig`
+Configurations for external builder VMs. 
+
+
+
+**Attributes:**
+ 
+ - <b>`flavor`</b>:  The OpenStack flavor to use for external builder VM. 
+ - <b>`network`</b>:  The OpenStack network to launch the builder VM. 
+
+
+
+
+---
+
+<a href="../src/state.py#L184"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+### <kbd>classmethod</kbd> `from_charm`
+
+```python
+from_charm(charm: CharmBase)
+```
+
+Initialize build configuration from current charm instance. 
+
+
+
+**Args:**
+ 
+ - <b>`charm`</b>:  The running charm instance. 
+
+
+
+**Returns:**
+ The external build configuration of the charm. 
 
 
 ---
@@ -309,7 +352,7 @@ Proxy configuration.
 
 ---
 
-<a href="../src/state.py#L152"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/state.py#L155"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `from_env`
 
@@ -330,7 +373,7 @@ Initialize the proxy config from charm.
 ## <kbd>class</kbd> `UnsupportedArchitectureError`
 Raised when given machine charm architecture is unsupported. 
 
-<a href="../src/state.py#L47"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/state.py#L50"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `__init__`
 

--- a/src-docs/state.py.md
+++ b/src-docs/state.py.md
@@ -64,7 +64,7 @@ The ubuntu OS base image to build and deploy runners on.
 ## <kbd>class</kbd> `BuildConfigInvalidError`
 Raised when charm config related to image build config is invalid. 
 
-<a href="../src/state.py#L50"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/state.py#L46"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `__init__`
 
@@ -107,7 +107,7 @@ This is managed by the application's git tag and versioning tag in pyproject.tom
 ## <kbd>class</kbd> `BuilderAppChannelInvalidError`
 Represents invalid builder app channel configuration. 
 
-<a href="../src/state.py#L50"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/state.py#L46"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `__init__`
 
@@ -147,7 +147,7 @@ The image builder setup config.
 
 ---
 
-<a href="../src/state.py#L466"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/state.py#L461"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `from_charm`
 
@@ -204,7 +204,7 @@ The cloud name from cloud_config.
 
 ---
 
-<a href="../src/state.py#L239"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/state.py#L234"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `from_charm`
 
@@ -237,7 +237,7 @@ Initialize build state from current charm instance.
 ## <kbd>class</kbd> `BuilderSetupConfigInvalidError`
 Raised when charm config related to image build setup config is invalid. 
 
-<a href="../src/state.py#L50"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/state.py#L46"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `__init__`
 
@@ -268,7 +268,7 @@ Raised when charm config is invalid.
  
  - <b>`msg`</b>:  Explanation of the error. 
 
-<a href="../src/state.py#L50"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/state.py#L46"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `__init__`
 
@@ -305,7 +305,7 @@ Configurations for external builder VMs.
 
 ---
 
-<a href="../src/state.py#L184"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/state.py#L180"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `from_charm`
 
@@ -354,7 +354,7 @@ Proxy configuration.
 
 ---
 
-<a href="../src/state.py#L155"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/state.py#L151"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `from_env`
 
@@ -375,7 +375,7 @@ Initialize the proxy config from charm.
 ## <kbd>class</kbd> `UnsupportedArchitectureError`
 Raised when given machine charm architecture is unsupported. 
 
-<a href="../src/state.py#L50"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/state.py#L46"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `__init__`
 

--- a/src-docs/state.py.md
+++ b/src-docs/state.py.md
@@ -147,7 +147,7 @@ The image builder setup config.
 
 ---
 
-<a href="../src/state.py#L461"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/state.py#L460"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `from_charm`
 
@@ -191,7 +191,6 @@ Configurations for running builder periodically.
  - <b>`external_build_config`</b>:  The external builder configuration values. 
  - <b>`num_revisions`</b>:  Number of images to keep before deletion. 
  - <b>`runner_version`</b>:  The GitHub runner version to embed in the image. Latest version if empty. 
- - <b>`callback_script`</b>:  Path to callback script. 
 
 
 ---
@@ -204,7 +203,7 @@ The cloud name from cloud_config.
 
 ---
 
-<a href="../src/state.py#L234"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/state.py#L233"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `from_charm`
 

--- a/src/builder.py
+++ b/src/builder.py
@@ -208,7 +208,8 @@ def run(config: state.BuilderRunConfig) -> str:
                 "--network",
                 config.external_build_config.network,
             ]
-        return subprocess.check_output(
+        # The arg "user" exists but pylint disagrees.
+        return subprocess.check_output(  # pylint: disable=unexpected-keyword-arg # nosec:B603
             args=commands,
             user=UBUNTU_USER,
             cwd=UBUNTU_HOME,

--- a/src/charm.py
+++ b/src/charm.py
@@ -6,7 +6,6 @@
 """Entrypoint for GithubRunnerImageBuilder charm."""
 
 import logging
-import os
 import typing
 
 import ops
@@ -20,39 +19,8 @@ import state
 logger = logging.getLogger(__name__)
 
 
-BUILD_SUCCESS_EVENT_NAME = "build_success"
-BUILD_FAIL_EVENT_NAME = "build_fail"
-OPENSTACK_IMAGE_ID_ENV = "OPENSTACK_IMAGE_ID"
-
-
-class BuildSuccessEvent(ops.EventBase):
-    """Represents a successful image build event."""
-
-
-class BuildFailedEvent(ops.EventBase):
-    """Represents a failed image build event."""
-
-
-class BuildEvents(ops.CharmEvents):
-    """Represents events triggered by image builder callback.
-
-    Attributes:
-        build_success: Represents a successful image build event.
-        build_failed: Represents a failed image build event.
-    """
-
-    build_success = ops.EventSource(BuildSuccessEvent)
-    build_failed = ops.EventSource(BuildFailedEvent)
-
-
 class GithubRunnerImageBuilderCharm(ops.CharmBase):
-    """Charm GitHubRunner image builder application.
-
-    Attributes:
-        on: Represents custom events managed by cron.
-    """
-
-    on = BuildEvents()
+    """Charm GitHubRunner image builder application."""
 
     def __init__(self, *args: typing.Any):
         """Initialize the charm.
@@ -64,8 +32,7 @@ class GithubRunnerImageBuilderCharm(ops.CharmBase):
         self.image_observer = image.Observer(self)
         self.framework.observe(self.on.install, self._on_install)
         self.framework.observe(self.on.config_changed, self._on_config_changed)
-        self.framework.observe(self.on.build_success, self._on_build_success)
-        self.framework.observe(self.on.build_failed, self._on_build_failed)
+        self.framework.observe(self.on.run_action, self._on_run_action)
 
     @charm_utils.block_if_invalid_config(defer=True)
     def _on_install(self, _: ops.InstallEvent) -> None:
@@ -76,47 +43,10 @@ class GithubRunnerImageBuilderCharm(ops.CharmBase):
         """
         self.unit.status = ops.MaintenanceStatus("Setting up Builder.")
         proxy.setup(proxy=state.ProxyConfig.from_env())
-        self._create_success_callback_script()
-        self._create_failed_callback_script()
         init_config = state.BuilderInitConfig.from_charm(self)
         builder.initialize(init_config=init_config)
         self.unit.status = ops.ActiveStatus("Waiting for first image.")
-        builder.run(config=init_config.run_config)
-
-    def _create_success_callback_script(self) -> None:
-        """Create callback script to propagate images."""
-        charm_dir = os.getenv("JUJU_CHARM_DIR")
-        cur_env = {
-            "JUJU_DISPATCH_PATH": f"hooks/{BUILD_SUCCESS_EVENT_NAME}",
-            "JUJU_MODEL_NAME": self.model.name,
-            "JUJU_UNIT_NAME": self.unit.name,
-            OPENSTACK_IMAGE_ID_ENV: "$OPENSTACK_IMAGE_ID",
-        }
-        env = " ".join(f'{key}="{val}"' for (key, val) in cur_env.items())
-        script_contents = f"""#! /bin/bash
-OPENSTACK_IMAGE_ID="$1"
-
-/usr/bin/juju-exec {self.unit.name} {env} {charm_dir}/dispatch
-"""
-        state.SUCCESS_CALLBACK_SCRIPT_PATH.write_text(script_contents, encoding="utf-8")
-        state.SUCCESS_CALLBACK_SCRIPT_PATH.chmod(0o755)
-
-    def _create_failed_callback_script(self) -> None:
-        """Create callback script to propagate images."""
-        charm_dir = os.getenv("JUJU_CHARM_DIR")
-        cur_env = {
-            "JUJU_DISPATCH_PATH": f"hooks/{BUILD_SUCCESS_EVENT_NAME}",
-            "JUJU_MODEL_NAME": self.model.name,
-            "JUJU_UNIT_NAME": self.unit.name,
-        }
-        env = " ".join(f'{key}="{val}"' for (key, val) in cur_env.items())
-        script_contents = f"""#! /bin/bash
-OPENSTACK_IMAGE_ID="$1"
-
-/usr/bin/juju-exec {self.unit.name} {env} {charm_dir}/dispatch
-"""
-        state.FAILED_CALLBACK_SCRIPT_PATH.write_text(script_contents, encoding="utf-8")
-        state.FAILED_CALLBACK_SCRIPT_PATH.chmod(0o755)
+        self._run()
 
     @charm_utils.block_if_invalid_config(defer=False)
     def _on_config_changed(self, _: ops.ConfigChangedEvent) -> None:
@@ -124,41 +54,24 @@ OPENSTACK_IMAGE_ID="$1"
         proxy.configure_aproxy(proxy=state.ProxyConfig.from_env())
         init_config = state.BuilderInitConfig.from_charm(self)
         builder.install_clouds_yaml(cloud_config=init_config.run_config.cloud_config)
-        if builder.configure_cron(
-            run_config=init_config.run_config, interval=init_config.interval
-        ):
-            builder.run(config=init_config.run_config)
-        self.unit.status = ops.ActiveStatus()
+        if builder.configure_cron(unit_name=self.unit.name, interval=init_config.interval):
+            self._run()
 
-    def _on_build_success(self, _: BuildSuccessEvent) -> None:
-        """Handle build success event."""
-        image_id = os.getenv(OPENSTACK_IMAGE_ID_ENV, "")
-        if not image_id:
-            self.unit.status = ops.ActiveStatus(
-                f"Failed to build image. Check {builder.OUTPUT_LOG_PATH}."
-            )
-            return
+    def _on_run_action(self, _: ops.EventBase) -> None:
+        """Handle the run action event."""
+        self._run()
+
+    def _run(self) -> None:
+        """Trigger an image build."""
+        self.unit.status = ops.ActiveStatus("Building image.")
         run_config = state.BuilderRunConfig.from_charm(self)
+        image_id = builder.run(config=run_config)
         self.image_observer.update_image_data(
             image_id=image_id, arch=run_config.arch, base=run_config.base
         )
+        self.unit.status = ops.ActiveStatus("Image build success. Checking and upgrading app.")
         builder.upgrade_app()
         self.unit.status = ops.ActiveStatus()
-
-    def _on_build_failed(self, _: BuildFailedEvent) -> None:
-        """Handle build failed event."""
-        self.unit.status = ops.ActiveStatus(
-            f"Failed to build image. Check {builder.OUTPUT_LOG_PATH}."
-        )
-        builder.upgrade_app()
-
-    def update_status(self, status: ops.StatusBase) -> None:
-        """Update the charm status.
-
-        Args:
-            status: The desired status instance.
-        """
-        self.unit.status = status
 
 
 if __name__ == "__main__":  # pragma: nocover

--- a/src/charm.py
+++ b/src/charm.py
@@ -56,7 +56,9 @@ class GithubRunnerImageBuilderCharm(ops.CharmBase):
         builder.install_clouds_yaml(cloud_config=init_config.run_config.cloud_config)
         if builder.configure_cron(unit_name=self.unit.name, interval=init_config.interval):
             self._run()
+        self.unit.status = ops.ActiveStatus()
 
+    @charm_utils.block_if_invalid_config(defer=False)
     def _on_run_action(self, _: ops.EventBase) -> None:
         """Handle the run action event."""
         self._run()
@@ -72,6 +74,14 @@ class GithubRunnerImageBuilderCharm(ops.CharmBase):
         self.unit.status = ops.ActiveStatus("Image build success. Checking and upgrading app.")
         builder.upgrade_app()
         self.unit.status = ops.ActiveStatus()
+
+    def update_status(self, status: ops.StatusBase) -> None:
+        """Update the charm status.
+
+        Args:
+            status: The desired status instance.
+        """
+        self.unit.status = status
 
 
 if __name__ == "__main__":  # pragma: nocover

--- a/src/state.py
+++ b/src/state.py
@@ -6,7 +6,6 @@
 import dataclasses
 import logging
 import os
-import pathlib
 import platform
 import typing
 from enum import Enum
@@ -35,9 +34,6 @@ OPENSTACK_USER_DOMAIN_CONFIG_NAME = "openstack-user-domain-name"
 OPENSTACK_USER_CONFIG_NAME = "openstack-user-name"
 REVISION_HISTORY_LIMIT_CONFIG_NAME = "revision-history-limit"
 RUNNER_VERSION_CONFIG_NAME = "runner-version"
-
-SUCCESS_CALLBACK_SCRIPT_PATH = pathlib.Path("/home/ubuntu/on_build_success_callback.sh")
-FAILED_CALLBACK_SCRIPT_PATH = pathlib.Path("/home/ubuntu/on_build_failed_callback.sh")
 
 
 class CharmConfigInvalidError(Exception):
@@ -229,7 +225,6 @@ class BuilderRunConfig:
     external_build_config: ExternalBuildConfig | None
     num_revisions: int
     runner_version: str
-    callback_script: pathlib.Path = SUCCESS_CALLBACK_SCRIPT_PATH
 
     @property
     def cloud_name(self) -> str:

--- a/src/state.py
+++ b/src/state.py
@@ -182,7 +182,7 @@ class ExternalBuildConfig:
     network: str
 
     @classmethod
-    def from_charm(cls, charm: ops.CharmBase):
+    def from_charm(cls, charm: ops.CharmBase) -> "ExternalBuildConfig":
         """Initialize build configuration from current charm instance.
 
         Args:
@@ -201,7 +201,7 @@ class ExternalBuildConfig:
             .lower()
             .strip()
         )
-        return cls(external_build_flavor=flavor_name, external_build_network=network_name)
+        return cls(flavor=flavor_name, network=network_name)
 
 
 class BuildConfigInvalidError(CharmConfigInvalidError):
@@ -451,14 +451,17 @@ class BuilderInitConfig:
 
     Attributes:
         channel: The application installation channel.
+        external_build: Whether the image builder should run in external build mode.
         interval: The interval in hours between each scheduled image builds.
         run_config: The configuration required to build the image.
+        unit_name: The charm unit name in which the builder is running on.
     """
 
     channel: BuilderAppChannel
     external_build: bool
     interval: int
     run_config: BuilderRunConfig
+    unit_name: str
 
     @classmethod
     def from_charm(cls, charm: ops.CharmBase) -> "BuilderInitConfig":
@@ -486,4 +489,5 @@ class BuilderInitConfig:
             external_build=typing.cast(bool, charm.config.get(EXTERNAL_BUILD_CONFIG_NAME, False)),
             run_config=run_config,
             interval=build_interval,
+            unit_name=charm.unit.name,
         )

--- a/src/state.py
+++ b/src/state.py
@@ -216,7 +216,6 @@ class BuilderRunConfig:
         external_build_config: The external builder configuration values.
         num_revisions: Number of images to keep before deletion.
         runner_version: The GitHub runner version to embed in the image. Latest version if empty.
-        callback_script: Path to callback script.
     """
 
     arch: Arch

--- a/src/state.py
+++ b/src/state.py
@@ -483,6 +483,7 @@ class BuilderInitConfig:
 
         return cls(
             channel=channel,
+            external_build=typing.cast(bool, charm.config.get(EXTERNAL_BUILD_CONFIG_NAME, False)),
             run_config=run_config,
             interval=build_interval,
         )

--- a/src/state.py
+++ b/src/state.py
@@ -23,6 +23,9 @@ LTS_IMAGE_VERSION_TAG_MAP = {"22.04": "jammy", "24.04": "noble"}
 APP_CHANNEL_CONFIG_NAME = "app-channel"
 BASE_IMAGE_CONFIG_NAME = "base-image"
 BUILD_INTERVAL_CONFIG_NAME = "build-interval"
+EXTERNAL_BUILD_CONFIG_NAME = "experimental-external-build"
+EXTERNAL_BUILD_FLAVOR_CONFIG_NAME = "experimental-external-build-flavor"
+EXTERNAL_BUILD_NETWORK_CONFIG_NAME = "experimental-external-build-network"
 OPENSTACK_AUTH_URL_CONFIG_NAME = "openstack-auth-url"
 # Bandit thinks this is a hardcoded password
 OPENSTACK_PASSWORD_CONFIG_NAME = "openstack-password"  # nosec: B105
@@ -166,6 +169,41 @@ class ProxyConfig:
         return cls(http=http_proxy, https=https_proxy, no_proxy=no_proxy)
 
 
+@dataclasses.dataclass
+class ExternalBuildConfig:
+    """Configurations for external builder VMs.
+
+    Attributes:
+        flavor: The OpenStack flavor to use for external builder VM.
+        network: The OpenStack network to launch the builder VM.
+    """
+
+    flavor: str
+    network: str
+
+    @classmethod
+    def from_charm(cls, charm: ops.CharmBase):
+        """Initialize build configuration from current charm instance.
+
+        Args:
+            charm: The running charm instance.
+
+        Returns:
+            The external build configuration of the charm.
+        """
+        flavor_name = (
+            typing.cast(str, charm.config.get(EXTERNAL_BUILD_FLAVOR_CONFIG_NAME, ""))
+            .lower()
+            .strip()
+        )
+        network_name = (
+            typing.cast(str, charm.config.get(EXTERNAL_BUILD_NETWORK_CONFIG_NAME, ""))
+            .lower()
+            .strip()
+        )
+        return cls(external_build_flavor=flavor_name, external_build_network=network_name)
+
+
 class BuildConfigInvalidError(CharmConfigInvalidError):
     """Raised when charm config related to image build config is invalid."""
 
@@ -179,6 +217,7 @@ class BuilderRunConfig:
         base: Ubuntu OS image to build from.
         cloud_config: The Openstack clouds.yaml passed as charm config.
         cloud_name: The Openstack cloud name to connect to from clouds.yaml.
+        external_build_config: The external builder configuration values.
         num_revisions: Number of images to keep before deletion.
         runner_version: The GitHub runner version to embed in the image. Latest version if empty.
         callback_script: Path to callback script.
@@ -187,6 +226,7 @@ class BuilderRunConfig:
     arch: Arch
     base: BaseImage
     cloud_config: dict[str, typing.Any]
+    external_build_config: ExternalBuildConfig | None
     num_revisions: int
     runner_version: str
     callback_script: pathlib.Path = SUCCESS_CALLBACK_SCRIPT_PATH
@@ -235,10 +275,17 @@ class BuilderRunConfig:
         except ValueError as exc:
             raise BuildConfigInvalidError(msg=str(exc)) from exc
 
+        external_build_enabled = typing.cast(
+            bool, charm.config.get(EXTERNAL_BUILD_CONFIG_NAME, False)
+        )
+
         return cls(
             arch=arch,
             base=base_image,
             cloud_config=cloud_config,
+            external_build_config=(
+                ExternalBuildConfig.from_charm(charm=charm) if external_build_enabled else None
+            ),
             num_revisions=revision_history_limit,
             runner_version=runner_version,
         )
@@ -404,13 +451,14 @@ class BuilderInitConfig:
 
     Attributes:
         channel: The application installation channel.
-        run_config: The configuration required to build the image.
         interval: The interval in hours between each scheduled image builds.
+        run_config: The configuration required to build the image.
     """
 
     channel: BuilderAppChannel
-    run_config: BuilderRunConfig
+    external_build: bool
     interval: int
+    run_config: BuilderRunConfig
 
     @classmethod
     def from_charm(cls, charm: ops.CharmBase) -> "BuilderInitConfig":

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -287,7 +287,9 @@ def test_configs_fixture(
     model: Model, charm_file: str, test_id: str, dispatch_time: datetime
 ) -> TestConfigs:
     """The test configuration values."""
-    return TestConfigs(model=model, charm_file=charm_file, dispatch_time=dispatch_time)
+    return TestConfigs(
+        model=model, charm_file=charm_file, dispatch_time=dispatch_time, test_id=test_id
+    )
 
 
 @pytest_asyncio.fixture(scope="module", name="app")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -130,7 +130,6 @@ def dispatch_time_fixture():
 
 
 @pytest_asyncio.fixture(scope="module", name="test_charm")
-@pytest.mark.usefixtures("dispatch_time")
 async def test_charm_fixture(
     model: Model, test_id: str, arch: Literal["amd64", "arm64"]
 ) -> AsyncGenerator[Application, None]:
@@ -284,6 +283,7 @@ def test_id_fixture() -> str:
 
 
 @pytest_asyncio.fixture(scope="module", name="app")
+@pytest.mark.usefixtures("dispatch_time")
 async def app_fixture(
     model: Model,
     charm_file: str,

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -10,6 +10,7 @@ import string
 # subprocess module is used to call juju cli directly due to constraints with private-endpoint
 # models
 import subprocess  # nosec: B404
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import AsyncGenerator, Generator, Literal, NamedTuple, Optional
 
@@ -122,7 +123,14 @@ async def model_fixture(
         yield ops_test.model
 
 
+@pytest.fixture(scope="module", name="dispatch_time")
+def dispatch_time_fixture():
+    """The timestamp of the start of the charm tests."""
+    return datetime.now(tz=timezone.utc)
+
+
 @pytest_asyncio.fixture(scope="module", name="test_charm")
+@pytest.mark.usefixtures("dispatch_time")
 async def test_charm_fixture(
     model: Model, test_id: str, arch: Literal["amd64", "arm64"]
 ) -> AsyncGenerator[Application, None]:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -290,6 +290,7 @@ async def app_fixture(
     test_id: str,
     private_endpoint_configs: PrivateEndpointConfigs,
     use_private_endpoint: bool,
+    dispatch_time: datetime,
 ) -> AsyncGenerator[Application, None]:
     """The deployed application fixture."""
     config = {
@@ -310,6 +311,7 @@ async def app_fixture(
     # if local LXD testing model, make the machine of VM type
     if not use_private_endpoint:
         base_machine_constraint += " virt-type=virtual-machine"
+    logger.info("Deploying image builder: %s", dispatch_time)
     app: Application = await model.deploy(
         charm_file,
         application_name=f"image-builder-operator-{test_id}",

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -26,13 +26,14 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.mark.asyncio
-async def test_build_image(app: Application, openstack_connection: Connection):
+async def test_build_image(
+    app: Application, openstack_connection: Connection, dispatch_time: datetime
+):
     """
     arrange: A deployed active charm.
     act: When openstack images are listed.
     assert: An image is built successfully.
     """
-    dispatch_time = datetime.now(tz=timezone.utc)
     config: dict = await app.get_config()
     image_base = config[BASE_IMAGE_CONFIG_NAME]["value"]
 

--- a/tests/integration/types.py
+++ b/tests/integration/types.py
@@ -4,8 +4,10 @@
 """Types used in the integration test."""
 
 import typing
+from datetime import datetime
 from pathlib import Path
 
+from juju.model import Model
 from openstack.compute.v2.keypair import Keypair
 
 
@@ -57,3 +59,19 @@ class PrivateEndpointConfigs(typing.TypedDict):
     user_domain_name: str
     username: str
     region_name: str
+
+
+class TestConfigs(typing.NamedTuple):
+    """Test configuration values.
+
+    Attributes:
+        model: The juju test model.
+        charm_file: The charm file path.
+        dispatch_time: The test start time.
+        test_id: The test unique identifier.
+    """
+
+    model: Model
+    charm_file: str | Path
+    dispatch_time: datetime
+    test_id: str

--- a/tests/unit/factories.py
+++ b/tests/unit/factories.py
@@ -39,6 +39,17 @@ class BaseMetaFactory(typing.Generic[T], factory.base.FactoryMetaClass):
         return super().__call__(*args, **kwargs)  # noqa: DCO030
 
 
+class MockUnitFactory(factory.Factory):
+    """Mock GitHubRunnerImageBuilder charm unit."""  # noqa: DCO060
+
+    class Meta:  # pylint: disable=too-few-public-methods
+        """Configuration for factory."""  # noqa: DCO060
+
+        model = MagicMock
+
+    name: str
+
+
 class MockCharmFactory(factory.Factory):
     """Mock GithubRunnerImageBuilder charm."""  # noqa: DCO060
 
@@ -48,7 +59,7 @@ class MockCharmFactory(factory.Factory):
         model = MagicMock
 
     app = MagicMock
-    unit = MagicMock
+    unit = MockUnitFactory()
     config = factory.Dict(
         {
             APP_CHANNEL_CONFIG_NAME: "edge",

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -6,7 +6,6 @@
 # Need access to protected functions for testing
 # pylint:disable=protected-access
 
-from pathlib import Path
 from unittest.mock import MagicMock
 
 import ops
@@ -16,7 +15,7 @@ import builder
 import image
 import proxy
 import state
-from charm import BUILD_SUCCESS_EVENT_NAME, GithubRunnerImageBuilderCharm, os
+from charm import GithubRunnerImageBuilderCharm
 
 
 @pytest.fixture(name="charm", scope="module")
@@ -57,38 +56,6 @@ def test_block_on_state_error(
     getattr(charm, hook)(MagicMock())
 
     assert charm.unit.status == ops.BlockedStatus("Invalid config")
-
-
-def test__create_callback_script(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, charm: GithubRunnerImageBuilderCharm
-):
-    """
-    arrange: given monkeypatched CALLBACK_SCRIPT_PATH.
-    act: when _create_callback_script is called.
-    assert: expected contents are written to path.
-    """
-    test_path = tmp_path / "test"
-    charm.unit.name = (test_unit_name := "test_unit_name")
-    charm.model.name = (test_model_name := "test_model_name")
-    monkeypatch.setattr(state, "SUCCESS_CALLBACK_SCRIPT_PATH", test_path)
-    monkeypatch.setattr(os, "getenv", MagicMock(return_value=(test_dir := "test_charm_dir")))
-
-    charm._create_success_callback_script()
-
-    contents = test_path.read_text(encoding="utf-8")
-    assert (
-        contents
-        == f"""#! /bin/bash
-OPENSTACK_IMAGE_ID="$1"
-
-/usr/bin/juju-exec {test_unit_name} \
-JUJU_DISPATCH_PATH="hooks/{BUILD_SUCCESS_EVENT_NAME}" \
-JUJU_MODEL_NAME="{test_model_name}" \
-JUJU_UNIT_NAME="{test_unit_name}" \
-OPENSTACK_IMAGE_ID="$OPENSTACK_IMAGE_ID" \
-{test_dir}/dispatch
-"""
-    )
 
 
 def test__on_install(monkeypatch: pytest.MonkeyPatch, charm: GithubRunnerImageBuilderCharm):
@@ -143,53 +110,3 @@ def test__on_config_changed(
     charm._on_config_changed(MagicMock())
 
     assert charm.unit.status == ops.ActiveStatus()
-
-
-def test__on_build_success_error(
-    monkeypatch: pytest.MonkeyPatch, charm: GithubRunnerImageBuilderCharm
-):
-    """
-    arrange: given a monkeypatched mock os.getenv function that returns no value.
-    act: when _on_build_success is called.
-    assert: the charm is in ActiveStatus with a message.
-    """
-    monkeypatch.setattr(os, "getenv", MagicMock(return_value=""))
-
-    charm._on_build_success(MagicMock)
-
-    assert isinstance(charm.unit.status, ops.ActiveStatus)
-    assert "Failed to build image." in charm.unit.status.message
-
-
-def test__on_build_success(monkeypatch: pytest.MonkeyPatch, charm: GithubRunnerImageBuilderCharm):
-    """
-    arrange: given a monkeypatched mock os.getenv function.
-    act: when _on_build_success is called.
-    assert: the charm is in active status.
-    """
-    monkeypatch.setattr(os, "getenv", MagicMock())
-    monkeypatch.setattr(builder, "upgrade_app", upgrade_mock := MagicMock())
-    monkeypatch.setattr(builder.state.BuilderRunConfig, "from_charm", MagicMock())
-    charm.image_observer.update_image_data = (update_mock := MagicMock())
-
-    charm._on_build_success(MagicMock)
-
-    assert charm.unit.status == ops.ActiveStatus()
-    upgrade_mock.assert_called_once()
-    update_mock.assert_called_once()
-
-
-def test__on_build_fail(monkeypatch: pytest.MonkeyPatch, charm: GithubRunnerImageBuilderCharm):
-    """
-    arrange: given monkeypatched mock builder upgrade_app function.
-    act: when _on_build_failed is called.
-    assert: the charm is in active status and the upgrade_app is called.
-    """
-    monkeypatch.setattr(builder, "upgrade_app", upgrade_mock := MagicMock())
-
-    charm._on_build_failed(MagicMock)
-
-    assert charm.unit.status == ops.ActiveStatus(
-        f"Failed to build image. Check {builder.OUTPUT_LOG_PATH}."
-    )
-    upgrade_mock.assert_called_once()


### PR DESCRIPTION
Applicable spec: ISD165

### Overview

- Fixes rustc build for cryptography lib
- Introduces `experimental-external-build*` configuration options to enable external (OpenStack VM) building of images.
- Refactor running of builds to be using `juju-exec` which outputs the logs via `juju debug-logs` which allows easier log viewing and prep work for COS integration.

### Rationale

- This is in preparation for custom images buliding.

### Juju Events Changes

- `run` action added to be triggered by `juju-exec`. This pattern is also applied to GitHub runner operator.

### Module Changes

- `charm.py` - Removed all callback functions and handles image uploading calls directly w/ juju-exec'ed run calls.
- `state.py` - Added state for external build configuration values.
- `builder.py` - Added flags for external build if enabled. Changed to use juju-exec calls for cron.

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [ ] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
The docs to be updated on a separate PR.