### PR TITLE
feat: external cloud

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -19,7 +19,6 @@ jobs:
       self-hosted-runner-arch: X64
       self-hosted-runner-label: stg-private-endpoint
       builder-runner-label: X64
-      tmate-debug: true
 
   integration-tests-arm:
     uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
@@ -33,4 +32,3 @@ jobs:
       self-hosted-runner-label: stg-private-endpoint
       builder-runner-label: ARM64
       pre-run-script: tests/integration/setup_private_endpoint.sh
-      tmate-debug: true

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -19,6 +19,7 @@ jobs:
       self-hosted-runner-arch: X64
       self-hosted-runner-label: stg-private-endpoint
       builder-runner-label: X64
+      tmate-debug;: true
 
   integration-tests-arm:
     uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -19,7 +19,7 @@ jobs:
       self-hosted-runner-arch: X64
       self-hosted-runner-label: stg-private-endpoint
       builder-runner-label: X64
-      tmate-debug;: true
+      tmate-debug: true
 
   integration-tests-arm:
     uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
@@ -33,3 +33,4 @@ jobs:
       self-hosted-runner-label: stg-private-endpoint
       builder-runner-label: ARM64
       pre-run-script: tests/integration/setup_private_endpoint.sh
+      tmate-debug: true

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,0 +1,22 @@
+## [#27 feat: external cloud](https://github.com/canonical/github-runner-image-builder-operator/pull/27) (2021-09-13)
+
+> Builds GitHub runner images on OpenStack VMs.
+
+### Upgrade Steps
+* Requires enough capacity on the OpenStack project cloud to launch builder VMs.
+* Requires GitHub Runner revision 249 and above.
+
+### Breaking Changes
+* None
+
+### New Features
+* None
+
+### Bug Fixes
+* None
+
+### Performance Improvements
+* None
+
+### Other Changes
+* None

--- a/src-docs/builder.py.md
+++ b/src-docs/builder.py.md
@@ -38,7 +38,7 @@ Configure the host machine to build images.
 
 ---
 
-<a href="../src/builder.py#L118"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/builder.py#L119"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `install_clouds_yaml`
 
@@ -57,7 +57,7 @@ Install clouds.yaml for Openstack used by the image builder.
 
 ---
 
-<a href="../src/builder.py#L131"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/builder.py#L132"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `configure_cron`
 
@@ -82,7 +82,7 @@ Configure cron to run builder.
 
 ---
 
-<a href="../src/builder.py#L174"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/builder.py#L175"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `run`
 
@@ -112,7 +112,7 @@ Run a build immediately.
 
 ---
 
-<a href="../src/builder.py#L227"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/builder.py#L228"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `get_latest_image`
 
@@ -144,7 +144,7 @@ Fetch the latest image build ID.
 
 ---
 
-<a href="../src/builder.py#L263"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/builder.py#L264"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `upgrade_app`
 

--- a/src-docs/builder.py.md
+++ b/src-docs/builder.py.md
@@ -112,7 +112,7 @@ Run a build immediately.
 
 ---
 
-<a href="../src/builder.py#L228"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/builder.py#L232"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `get_latest_image`
 
@@ -144,7 +144,7 @@ Fetch the latest image build ID.
 
 ---
 
-<a href="../src/builder.py#L264"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/builder.py#L268"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `upgrade_app`
 

--- a/src-docs/builder.py.md
+++ b/src-docs/builder.py.md
@@ -112,7 +112,7 @@ Run a build immediately.
 
 ---
 
-<a href="../src/builder.py#L223"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/builder.py#L225"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `get_latest_image`
 
@@ -144,7 +144,7 @@ Fetch the latest image build ID.
 
 ---
 
-<a href="../src/builder.py#L259"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/builder.py#L261"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `upgrade_app`
 

--- a/src-docs/builder.py.md
+++ b/src-docs/builder.py.md
@@ -87,7 +87,7 @@ Configure cron to run builder.
 ## <kbd>function</kbd> `run`
 
 ```python
-run(config: BuilderRunConfig) → str
+run(config: BuilderRunConfig, proxy: ProxyConfig | None) → str
 ```
 
 Run a build immediately. 
@@ -97,6 +97,7 @@ Run a build immediately.
 **Args:**
  
  - <b>`config`</b>:  The configuration values for running image builder. 
+ - <b>`proxy`</b>:  The proxy configuration to apply on the builder. 
 
 
 
@@ -112,7 +113,7 @@ Run a build immediately.
 
 ---
 
-<a href="../src/builder.py#L235"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/builder.py#L238"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `get_latest_image`
 
@@ -144,7 +145,7 @@ Fetch the latest image build ID.
 
 ---
 
-<a href="../src/builder.py#L271"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/builder.py#L274"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `upgrade_app`
 

--- a/src-docs/builder.py.md
+++ b/src-docs/builder.py.md
@@ -112,7 +112,7 @@ Run a build immediately.
 
 ---
 
-<a href="../src/builder.py#L233"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/builder.py#L235"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `get_latest_image`
 
@@ -144,7 +144,7 @@ Fetch the latest image build ID.
 
 ---
 
-<a href="../src/builder.py#L269"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/builder.py#L271"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `upgrade_app`
 

--- a/src-docs/builder.py.md
+++ b/src-docs/builder.py.md
@@ -38,7 +38,7 @@ Configure the host machine to build images.
 
 ---
 
-<a href="../src/builder.py#L119"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/builder.py#L118"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `install_clouds_yaml`
 
@@ -57,7 +57,7 @@ Install clouds.yaml for Openstack used by the image builder.
 
 ---
 
-<a href="../src/builder.py#L132"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/builder.py#L131"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `configure_cron`
 
@@ -82,7 +82,7 @@ Configure cron to run builder.
 
 ---
 
-<a href="../src/builder.py#L175"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/builder.py#L174"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `run`
 
@@ -112,7 +112,7 @@ Run a build immediately.
 
 ---
 
-<a href="../src/builder.py#L232"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/builder.py#L233"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `get_latest_image`
 
@@ -144,7 +144,7 @@ Fetch the latest image build ID.
 
 ---
 
-<a href="../src/builder.py#L268"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/builder.py#L269"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `upgrade_app`
 

--- a/src-docs/builder.py.md
+++ b/src-docs/builder.py.md
@@ -113,7 +113,7 @@ Run a build immediately.
 
 ---
 
-<a href="../src/builder.py#L238"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/builder.py#L240"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `get_latest_image`
 
@@ -145,7 +145,7 @@ Fetch the latest image build ID.
 
 ---
 
-<a href="../src/builder.py#L274"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/builder.py#L276"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `upgrade_app`
 

--- a/src-docs/builder.py.md
+++ b/src-docs/builder.py.md
@@ -38,7 +38,7 @@ Configure the host machine to build images.
 
 ---
 
-<a href="../src/builder.py#L116"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/builder.py#L118"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `install_clouds_yaml`
 
@@ -57,7 +57,7 @@ Install clouds.yaml for Openstack used by the image builder.
 
 ---
 
-<a href="../src/builder.py#L129"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/builder.py#L131"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `configure_cron`
 
@@ -82,7 +82,7 @@ Configure cron to run builder.
 
 ---
 
-<a href="../src/builder.py#L172"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/builder.py#L174"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `run`
 
@@ -112,7 +112,7 @@ Run a build immediately.
 
 ---
 
-<a href="../src/builder.py#L225"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/builder.py#L227"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `get_latest_image`
 
@@ -144,7 +144,7 @@ Fetch the latest image build ID.
 
 ---
 
-<a href="../src/builder.py#L261"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/builder.py#L263"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `upgrade_app`
 

--- a/src-docs/charm.py.md
+++ b/src-docs/charm.py.md
@@ -69,7 +69,7 @@ Unit that this execution is responsible for.
 
 ---
 
-<a href="../src/charm.py#L102"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm.py#L110"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `update_status`
 

--- a/src-docs/charm.py.md
+++ b/src-docs/charm.py.md
@@ -69,7 +69,7 @@ Unit that this execution is responsible for.
 
 ---
 
-<a href="../src/charm.py#L125"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm.py#L124"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `update_status`
 

--- a/src-docs/charm.py.md
+++ b/src-docs/charm.py.md
@@ -69,7 +69,7 @@ Unit that this execution is responsible for.
 
 ---
 
-<a href="../src/charm.py#L110"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm.py#L125"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `update_status`
 

--- a/src-docs/charm.py.md
+++ b/src-docs/charm.py.md
@@ -69,7 +69,7 @@ Unit that this execution is responsible for.
 
 ---
 
-<a href="../src/charm.py#L124"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm.py#L125"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `update_status`
 

--- a/src-docs/charm.py.md
+++ b/src-docs/charm.py.md
@@ -69,7 +69,7 @@ Unit that this execution is responsible for.
 
 ---
 
-<a href="../src/charm.py#L78"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm.py#L102"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `update_status`
 

--- a/src-docs/image.py.md
+++ b/src-docs/image.py.md
@@ -5,9 +5,6 @@
 # <kbd>module</kbd> `image.py`
 The Github-runner-image-builder-operator image relation observer. 
 
-**Global Variables**
----------------
-- **IMAGE_RELATION**
 
 
 ---
@@ -31,7 +28,7 @@ Relation data for providing image ID.
 ## <kbd>class</kbd> `Observer`
 The image relation observer. 
 
-<a href="../src/image.py#L35"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/image.py#L33"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `__init__`
 
@@ -58,7 +55,7 @@ Shortcut for more simple access the model.
 
 ---
 
-<a href="../src/image.py#L62"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/image.py#L60"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `update_image_data`
 

--- a/src-docs/state.py.md
+++ b/src-docs/state.py.md
@@ -149,7 +149,7 @@ The image builder setup config.
 
 ---
 
-<a href="../src/state.py#L493"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/state.py#L509"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `from_charm`
 
@@ -205,7 +205,7 @@ The cloud name from cloud_config.
 
 ---
 
-<a href="../src/state.py#L260"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/state.py#L276"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `from_charm`
 
@@ -344,7 +344,7 @@ The OpenStack cloud authentication data.
 
 ---
 
-<a href="../src/state.py#L532"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/state.py#L549"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `from_charm`
 
@@ -353,6 +353,17 @@ from_charm(charm: CharmBase) → GitHubRunnerOpenStackConfig | None
 ```
 
 Get the Github runner's OpenStack configuration from integratiotn data. 
+
+
+
+**Args:**
+ 
+ - <b>`charm`</b>:  The running charm instance. 
+
+
+
+**Returns:**
+ GitHubRunnerOpenStackConfig if it exists on the relation. 
 
 
 ---

--- a/src-docs/state.py.md
+++ b/src-docs/state.py.md
@@ -149,7 +149,7 @@ The image builder setup config.
 
 ---
 
-<a href="../src/state.py#L509"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/state.py#L511"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `from_charm`
 
@@ -344,7 +344,7 @@ The OpenStack cloud authentication data.
 
 ---
 
-<a href="../src/state.py#L549"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/state.py#L551"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `from_charm`
 

--- a/src-docs/state.py.md
+++ b/src-docs/state.py.md
@@ -10,6 +10,7 @@ Module for interacting with charm state and configurations.
 - **ARCHITECTURES_ARM64**
 - **ARCHITECTURES_X86**
 - **CLOUD_NAME**
+- **UPLOAD_CLOUD_NAME**
 - **LTS_IMAGE_VERSION_TAG_MAP**
 - **APP_CHANNEL_CONFIG_NAME**
 - **BASE_IMAGE_CONFIG_NAME**
@@ -25,6 +26,7 @@ Module for interacting with charm state and configurations.
 - **OPENSTACK_USER_CONFIG_NAME**
 - **REVISION_HISTORY_LIMIT_CONFIG_NAME**
 - **RUNNER_VERSION_CONFIG_NAME**
+- **IMAGE_RELATION**
 
 
 ---
@@ -64,7 +66,7 @@ The ubuntu OS base image to build and deploy runners on.
 ## <kbd>class</kbd> `BuildConfigInvalidError`
 Raised when charm config related to image build config is invalid. 
 
-<a href="../src/state.py#L46"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/state.py#L49"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `__init__`
 
@@ -107,7 +109,7 @@ This is managed by the application's git tag and versioning tag in pyproject.tom
 ## <kbd>class</kbd> `BuilderAppChannelInvalidError`
 Represents invalid builder app channel configuration. 
 
-<a href="../src/state.py#L46"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/state.py#L49"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `__init__`
 
@@ -147,7 +149,7 @@ The image builder setup config.
 
 ---
 
-<a href="../src/state.py#L460"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/state.py#L493"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `from_charm`
 
@@ -203,7 +205,7 @@ The cloud name from cloud_config.
 
 ---
 
-<a href="../src/state.py#L233"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/state.py#L260"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `from_charm`
 
@@ -236,7 +238,7 @@ Initialize build state from current charm instance.
 ## <kbd>class</kbd> `BuilderSetupConfigInvalidError`
 Raised when charm config related to image build setup config is invalid. 
 
-<a href="../src/state.py#L46"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/state.py#L49"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `__init__`
 
@@ -267,7 +269,7 @@ Raised when charm config is invalid.
  
  - <b>`msg`</b>:  Explanation of the error. 
 
-<a href="../src/state.py#L46"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/state.py#L49"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `__init__`
 
@@ -304,7 +306,7 @@ Configurations for external builder VMs.
 
 ---
 
-<a href="../src/state.py#L180"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/state.py#L183"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `from_charm`
 
@@ -328,8 +330,50 @@ Initialize build configuration from current charm instance.
 
 ---
 
+## <kbd>class</kbd> `GitHubRunnerOpenStackConfig`
+The OpenStack cloud authentication data. 
+
+
+
+**Attributes:**
+ 
+ - <b>`auth`</b>:  The cloud authentication data. 
+
+
+
+
+---
+
+<a href="../src/state.py#L532"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+### <kbd>classmethod</kbd> `from_charm`
+
+```python
+from_charm(charm: CharmBase) → GitHubRunnerOpenStackConfig | None
+```
+
+Get the Github runner's OpenStack configuration from integratiotn data. 
+
+
+---
+
 ## <kbd>class</kbd> `InvalidCloudConfigError`
 Represents an error with openstack cloud config. 
+
+
+
+
+
+---
+
+## <kbd>class</kbd> `OpenstackCloudsConfig`
+The Openstack clouds.yaml configuration mapping. 
+
+
+
+**Attributes:**
+ 
+ - <b>`clouds`</b>:  The mapping of cloud to cloud configuration values. 
 
 
 
@@ -353,7 +397,7 @@ Proxy configuration.
 
 ---
 
-<a href="../src/state.py#L151"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/state.py#L154"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `from_env`
 
@@ -374,7 +418,7 @@ Initialize the proxy config from charm.
 ## <kbd>class</kbd> `UnsupportedArchitectureError`
 Raised when given machine charm architecture is unsupported. 
 
-<a href="../src/state.py#L46"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/state.py#L49"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `__init__`
 

--- a/src-docs/state.py.md
+++ b/src-docs/state.py.md
@@ -149,7 +149,7 @@ The image builder setup config.
 
 ---
 
-<a href="../src/state.py#L511"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/state.py#L509"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `from_charm`
 
@@ -344,7 +344,7 @@ The OpenStack cloud authentication data.
 
 ---
 
-<a href="../src/state.py#L551"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/state.py#L549"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `from_charm`
 

--- a/src/builder.py
+++ b/src/builder.py
@@ -171,11 +171,12 @@ def _should_configure_cron(cron_contents: str) -> bool:
     return cron_contents != CRON_BUILD_SCHEDULE_PATH.read_text(encoding="utf-8")
 
 
-def run(config: state.BuilderRunConfig) -> str:
+def run(config: state.BuilderRunConfig, proxy: state.ProxyConfig | None) -> str:
     """Run a build immediately.
 
     Args:
         config: The configuration values for running image builder.
+        proxy: The proxy configuration to apply on the builder.
 
     Raises:
         BuilderRunError: if there was an error while launching the subprocess.
@@ -216,6 +217,8 @@ def run(config: state.BuilderRunConfig) -> str:
                     state.UPLOAD_CLOUD_NAME,
                 ]
             )
+        if proxy:
+            commands.extend(["--proxy", proxy.http])
         # The arg "user" exists but pylint disagrees.
         stdout = subprocess.check_output(  # pylint: disable=unexpected-keyword-arg # nosec:B603
             args=commands,

--- a/src/builder.py
+++ b/src/builder.py
@@ -218,7 +218,9 @@ def run(config: state.BuilderRunConfig, proxy: state.ProxyConfig | None) -> str:
                 ]
             )
         if proxy:
-            commands.extend(["--proxy", proxy.http])
+            commands.extend(
+                ["--proxy", proxy.http.removeprefix("http://").removeprefix("https://")]
+            )
         # The arg "user" exists but pylint disagrees.
         stdout = subprocess.check_output(  # pylint: disable=unexpected-keyword-arg # nosec:B603
             args=commands,

--- a/src/builder.py
+++ b/src/builder.py
@@ -214,13 +214,17 @@ def run(config: state.BuilderRunConfig) -> str:
                 state.UPLOAD_CLOUD_NAME,
             ]
         # The arg "user" exists but pylint disagrees.
-        return subprocess.check_output(  # pylint: disable=unexpected-keyword-arg # nosec:B603
+        stdout = subprocess.check_output(  # pylint: disable=unexpected-keyword-arg # nosec:B603
             args=commands,
             user=UBUNTU_USER,
             cwd=UBUNTU_HOME,
             encoding="utf-8",
             env={"HOME": str(UBUNTU_HOME)},
         )
+        if "Image build success" not in stdout:
+            raise BuilderRunError(f"Unexpected output: {stdout}")
+        # The return value of the CLI is "Image build success:\n<image-id>"
+        return stdout.split()[-1]
     except subprocess.SubprocessError as exc:
         raise BuilderRunError from exc
 

--- a/src/builder.py
+++ b/src/builder.py
@@ -207,6 +207,8 @@ def run(config: state.BuilderRunConfig) -> str:
                 config.external_build_config.flavor,
                 "--network",
                 config.external_build_config.network,
+                "--upload-cloud",
+                state.UPLOAD_CLOUD_NAME,
             ]
         # The arg "user" exists but pylint disagrees.
         return subprocess.check_output(  # pylint: disable=unexpected-keyword-arg # nosec:B603

--- a/src/builder.py
+++ b/src/builder.py
@@ -99,10 +99,9 @@ def _initialize_image_builder(init_config: state.BuilderInitConfig) -> None:
     """
     init_cmd = ["/usr/bin/sudo", str(GITHUB_RUNNER_IMAGE_BUILDER_PATH), "init"]
     if init_config.external_build:
-        init_cmd += "--experimental-external"
-        init_cmd += "True"
-        init_cmd += "--cloud-name"
-        init_cmd += init_config.run_config.cloud_name
+        init_cmd.extend(
+            ["--experimental-external", "True", "--cloud-name", init_config.run_config.cloud_name]
+        )
     try:
         subprocess.run(
             init_cmd,
@@ -201,18 +200,20 @@ def run(config: state.BuilderRunConfig) -> str:
             str(config.num_revisions),
         ]
         if config.runner_version:
-            commands += ["--runner-version", config.runner_version]
+            commands.extend(["--runner-version", config.runner_version])
         if config.external_build_config:
-            commands += [
-                "--experimental-external",
-                "True",
-                "--flavor",
-                config.external_build_config.flavor,
-                "--network",
-                config.external_build_config.network,
-                "--upload-cloud",
-                state.UPLOAD_CLOUD_NAME,
-            ]
+            commands.extend(
+                [
+                    "--experimental-external",
+                    "True",
+                    "--flavor",
+                    config.external_build_config.flavor,
+                    "--network",
+                    config.external_build_config.network,
+                    "--upload-cloud",
+                    state.UPLOAD_CLOUD_NAME,
+                ]
+            )
         # The arg "user" exists but pylint disagrees.
         stdout = subprocess.check_output(  # pylint: disable=unexpected-keyword-arg # nosec:B603
             args=commands,

--- a/src/builder.py
+++ b/src/builder.py
@@ -100,6 +100,8 @@ def _initialize_image_builder(init_config: state.BuilderInitConfig) -> None:
     init_cmd = ["/usr/bin/sudo", str(GITHUB_RUNNER_IMAGE_BUILDER_PATH), "init"]
     if init_config.external_build:
         init_cmd += "--experimental-external"
+        init_cmd += "--cloud-name"
+        init_cmd += init_config.run_config.cloud_name
     try:
         subprocess.run(
             init_cmd,

--- a/src/builder.py
+++ b/src/builder.py
@@ -100,6 +100,7 @@ def _initialize_image_builder(init_config: state.BuilderInitConfig) -> None:
     init_cmd = ["/usr/bin/sudo", str(GITHUB_RUNNER_IMAGE_BUILDER_PATH), "init"]
     if init_config.external_build:
         init_cmd += "--experimental-external"
+        init_cmd += "True"
         init_cmd += "--cloud-name"
         init_cmd += init_config.run_config.cloud_name
     try:

--- a/src/builder.py
+++ b/src/builder.py
@@ -221,7 +221,7 @@ def run(config: state.BuilderRunConfig) -> str:
             encoding="utf-8",
             env={"HOME": str(UBUNTU_HOME)},
         )
-        if "Image build success" not in stdout:
+        if config.external_build_config and "Image build success" not in stdout:
             raise BuilderRunError(f"Unexpected output: {stdout}")
         # The return value of the CLI is "Image build success:\n<image-id>"
         return stdout.split()[-1]

--- a/src/builder.py
+++ b/src/builder.py
@@ -206,6 +206,8 @@ def run(config: state.BuilderRunConfig) -> str:
                 [
                     "--experimental-external",
                     "True",
+                    "--arch",
+                    config.arch.value,
                     "--flavor",
                     config.external_build_config.flavor,
                     "--network",

--- a/src/charm.py
+++ b/src/charm.py
@@ -47,6 +47,7 @@ class GithubRunnerImageBuilderCharm(ops.CharmBase):
         self.unit.status = ops.MaintenanceStatus("Setting up Builder.")
         proxy.setup(proxy=state.ProxyConfig.from_env())
         init_config = state.BuilderInitConfig.from_charm(self)
+        builder.install_clouds_yaml(cloud_config=init_config.run_config.cloud_config)
         builder.initialize(init_config=init_config)
         self.unit.status = ops.ActiveStatus("Waiting for first image.")
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -63,15 +63,14 @@ class GithubRunnerImageBuilderCharm(ops.CharmBase):
         self.unit.status = ops.ActiveStatus()
 
     @charm_utils.block_if_invalid_config(defer=False)
-    def _on_image_relation_changed(self, _: ops.RelationJoinedEvent) -> None:
+    def _on_image_relation_changed(self, _: ops.RelationChangedEvent) -> None:
         """Handle charm image relation changed event."""
         init_config = state.BuilderInitConfig.from_charm(self)
         if not self._is_image_relation_ready_set_status(config=init_config.run_config):
             return
         proxy.configure_aproxy(proxy=state.ProxyConfig.from_env())
         builder.install_clouds_yaml(cloud_config=init_config.run_config.cloud_config)
-        if builder.configure_cron(unit_name=self.unit.name, interval=init_config.interval):
-            self._run()
+        self._run()
         self.unit.status = ops.ActiveStatus()
 
     @charm_utils.block_if_invalid_config(defer=False)

--- a/src/charm.py
+++ b/src/charm.py
@@ -57,6 +57,7 @@ class GithubRunnerImageBuilderCharm(ops.CharmBase):
         builder.install_clouds_yaml(cloud_config=init_config.run_config.cloud_config)
         if builder.configure_cron(unit_name=self.unit.name, interval=init_config.interval):
             self._run()
+        self.unit.status = ops.ActiveStatus()
 
     @charm_utils.block_if_invalid_config(defer=False)
     def _on_run_action(self, event: ops.ActionEvent) -> None:
@@ -71,8 +72,15 @@ class GithubRunnerImageBuilderCharm(ops.CharmBase):
             return
         self._run()
 
-    def _is_image_relation_ready_set_status(self, config: state.BuilderRunConfig):
-        """Check if image relation is ready and set according status otherwise."""
+    def _is_image_relation_ready_set_status(self, config: state.BuilderRunConfig) -> bool:
+        """Check if image relation is ready and set according status otherwise.
+
+        Args:
+            config: The image builder run configuration.
+
+        Returns:
+            Whether the image relation is ready.
+        """
         if state.UPLOAD_CLOUD_NAME not in config.cloud_config["clouds"]:
             self.unit.status = ops.BlockedStatus(f"{state.IMAGE_RELATION} integration required.")
             return False

--- a/src/charm.py
+++ b/src/charm.py
@@ -114,7 +114,7 @@ class GithubRunnerImageBuilderCharm(ops.CharmBase):
         """
         self.unit.status = ops.ActiveStatus("Building image.")
         run_config = state.BuilderRunConfig.from_charm(self)
-        image_id = builder.run(config=run_config)
+        image_id = builder.run(config=run_config, proxy=proxy.ProxyConfig.from_env())
         self.image_observer.update_image_data(
             image_id=image_id, arch=run_config.arch, base=run_config.base
         )

--- a/src/image.py
+++ b/src/image.py
@@ -14,8 +14,6 @@ import state
 
 logger = logging.getLogger(__name__)
 
-IMAGE_RELATION = "image"
-
 
 class ImageRelationData(TypedDict):
     """Relation data for providing image ID.
@@ -42,7 +40,7 @@ class Observer(ops.Object):
         self.charm = charm
 
         charm.framework.observe(
-            charm.on[IMAGE_RELATION].relation_joined, self._on_image_relation_joined
+            charm.on[state.IMAGE_RELATION].relation_joined, self._on_image_relation_joined
         )
 
     @charm_utils.block_if_invalid_config(defer=False)
@@ -72,7 +70,7 @@ class Observer(ops.Object):
             arch: The architecture in which the image was built for.
             base: The OS base image.
         """
-        for relation in self.model.relations[IMAGE_RELATION]:
+        for relation in self.model.relations[state.IMAGE_RELATION]:
             relation.data[self.model.unit].update(
                 ImageRelationData(id=image_id, tags=",".join((arch.value, base.value)))
             )

--- a/src/state.py
+++ b/src/state.py
@@ -464,8 +464,6 @@ class BuilderAppChannel(str, Enum):
 
     EDGE = "edge"
     STABLE = "stable"
-    # This is only for testing with latest version of image-builder app.
-    TEST = "test"
 
     @classmethod
     def from_charm(cls, charm: ops.CharmBase) -> "BuilderAppChannel":
@@ -560,7 +558,7 @@ class GitHubRunnerOpenStackConfig:
         """
         for relation in charm.model.relations.get(IMAGE_RELATION, []):
             if not relation.units:
-                logger.warn(f"Units not yet joined {IMAGE_RELATION} relation.")
+                logger.warning("Units not yet joined %s relation.", IMAGE_RELATION)
                 return None
             for unit in relation.units:
                 if not relation.data[unit] or any(
@@ -574,7 +572,7 @@ class GitHubRunnerOpenStackConfig:
                         "username",
                     )
                 ):
-                    logger.warn("%s required field not yet set.", IMAGE_RELATION)
+                    logger.warning("%s required field not yet set.", IMAGE_RELATION)
                     continue
                 return cls(
                     auth=_CloudsAuthConfig(

--- a/src/state.py
+++ b/src/state.py
@@ -560,9 +560,21 @@ class GitHubRunnerOpenStackConfig:
         """
         for relation in charm.model.relations.get(IMAGE_RELATION, []):
             if not relation.units:
+                logger.warn(f"Units not yet joined {IMAGE_RELATION} relation.")
                 return None
             for unit in relation.units:
-                if not relation.data[unit]:
+                if not relation.data[unit] or any(
+                    required_field not in relation.data[unit]
+                    for required_field in (
+                        "auth_url",
+                        "password",
+                        "project_domain_name",
+                        "project_name",
+                        "user_domain_name",
+                        "username",
+                    )
+                ):
+                    logger.warn("%s required field not yet set.", IMAGE_RELATION)
                     continue
                 return cls(
                     auth=_CloudsAuthConfig(
@@ -574,5 +586,4 @@ class GitHubRunnerOpenStackConfig:
                         username=relation.data[unit]["username"],
                     )
                 )
-        # Denotes relation exists but waiting for data.
-        return cls(auth=None)
+        return None

--- a/src/state.py
+++ b/src/state.py
@@ -464,6 +464,8 @@ class BuilderAppChannel(str, Enum):
 
     EDGE = "edge"
     STABLE = "stable"
+    # This is only for testing with latest version of image-builder app.
+    TEST = "test"
 
     @classmethod
     def from_charm(cls, charm: ops.CharmBase) -> "BuilderAppChannel":

--- a/src/state.py
+++ b/src/state.py
@@ -530,7 +530,7 @@ class GitHubRunnerOpenStackConfig:
     auth: _CloudsAuthConfig | None
 
     @classmethod
-    def from_charm(cls, charm: ops.CharmBase) -> "GitHubRunnerOpenStackConfig" | None:
+    def from_charm(cls, charm: ops.CharmBase) -> "GitHubRunnerOpenStackConfig | None":
         """Get the Github runner's OpenStack configuration from integratiotn data."""
         for relation in charm.model.relations[IMAGE_RELATION]:
             if not relation.units:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -330,8 +330,8 @@ async def app_fixture(
         OPENSTACK_USER_CONFIG_NAME: private_endpoint_configs["username"],
         OPENSTACK_USER_DOMAIN_CONFIG_NAME: private_endpoint_configs["user_domain_name"],
         EXTERNAL_BUILD_CONFIG_NAME: "True",
-        EXTERNAL_BUILD_FLAVOR_CONFIG_NAME: network_name,
-        EXTERNAL_BUILD_NETWORK_CONFIG_NAME: flavor_name,
+        EXTERNAL_BUILD_FLAVOR_CONFIG_NAME: flavor_name,
+        EXTERNAL_BUILD_NETWORK_CONFIG_NAME: network_name,
     }
 
     base_machine_constraint = (

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -35,6 +35,9 @@ from state import (
     APP_CHANNEL_CONFIG_NAME,
     BASE_IMAGE_CONFIG_NAME,
     BUILD_INTERVAL_CONFIG_NAME,
+    EXTERNAL_BUILD_CONFIG_NAME,
+    EXTERNAL_BUILD_FLAVOR_CONFIG_NAME,
+    EXTERNAL_BUILD_NETWORK_CONFIG_NAME,
     OPENSTACK_AUTH_URL_CONFIG_NAME,
     OPENSTACK_PASSWORD_CONFIG_NAME,
     OPENSTACK_PROJECT_CONFIG_NAME,
@@ -311,6 +314,8 @@ async def app_fixture(
     test_configs: TestConfigs,
     private_endpoint_configs: PrivateEndpointConfigs,
     use_private_endpoint: bool,
+    network_name: str,
+    flavor_name: str,
 ) -> AsyncGenerator[Application, None]:
     """The deployed application fixture."""
     config = {
@@ -324,6 +329,9 @@ async def app_fixture(
         OPENSTACK_PROJECT_DOMAIN_CONFIG_NAME: private_endpoint_configs["project_domain_name"],
         OPENSTACK_USER_CONFIG_NAME: private_endpoint_configs["username"],
         OPENSTACK_USER_DOMAIN_CONFIG_NAME: private_endpoint_configs["user_domain_name"],
+        EXTERNAL_BUILD_CONFIG_NAME: "True",
+        EXTERNAL_BUILD_FLAVOR_CONFIG_NAME: network_name,
+        EXTERNAL_BUILD_NETWORK_CONFIG_NAME: flavor_name,
     }
 
     base_machine_constraint = (

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -322,7 +322,7 @@ async def app_fixture(
         APP_CHANNEL_CONFIG_NAME: "edge",
         BASE_IMAGE_CONFIG_NAME: "jammy",
         BUILD_INTERVAL_CONFIG_NAME: 12,
-        REVISION_HISTORY_LIMIT_CONFIG_NAME: 2,
+        REVISION_HISTORY_LIMIT_CONFIG_NAME: 5,
         OPENSTACK_AUTH_URL_CONFIG_NAME: private_endpoint_configs["auth_url"],
         OPENSTACK_PASSWORD_CONFIG_NAME: private_endpoint_configs["password"],
         OPENSTACK_PROJECT_CONFIG_NAME: private_endpoint_configs["project_name"],
@@ -474,8 +474,6 @@ async def openstack_server_fixture(
     yield server
 
     openstack_metadata.connection.delete_server(server_name, wait=True)
-    for image in images:
-        openstack_metadata.connection.delete_image(image.id)
 
 
 @pytest_asyncio.fixture(scope="module", name="ssh_connection")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -314,7 +314,7 @@ async def app_fixture(
 ) -> AsyncGenerator[Application, None]:
     """The deployed application fixture."""
     config = {
-        APP_CHANNEL_CONFIG_NAME: "test",
+        APP_CHANNEL_CONFIG_NAME: "edge",
         BUILD_INTERVAL_CONFIG_NAME: 12,
         REVISION_HISTORY_LIMIT_CONFIG_NAME: 2,
         OPENSTACK_AUTH_URL_CONFIG_NAME: private_endpoint_configs["auth_url"],

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -315,7 +315,7 @@ async def app_fixture(
     """The deployed application fixture."""
     config = {
         APP_CHANNEL_CONFIG_NAME: "edge",
-        BASE_IMAGE_CONFIG_NAME: "jammy,noble",
+        BASE_IMAGE_CONFIG_NAME: "jammy",
         BUILD_INTERVAL_CONFIG_NAME: 12,
         REVISION_HISTORY_LIMIT_CONFIG_NAME: 2,
         OPENSTACK_AUTH_URL_CONFIG_NAME: private_endpoint_configs["auth_url"],

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -315,6 +315,7 @@ async def app_fixture(
     """The deployed application fixture."""
     config = {
         APP_CHANNEL_CONFIG_NAME: "edge",
+        BASE_IMAGE_CONFIG_NAME: "jammy,noble",
         BUILD_INTERVAL_CONFIG_NAME: 12,
         REVISION_HISTORY_LIMIT_CONFIG_NAME: 2,
         OPENSTACK_AUTH_URL_CONFIG_NAME: private_endpoint_configs["auth_url"],

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -131,7 +131,10 @@ def dispatch_time_fixture():
 
 @pytest_asyncio.fixture(scope="module", name="test_charm")
 async def test_charm_fixture(
-    model: Model, test_id: str, arch: Literal["amd64", "arm64"]
+    model: Model,
+    test_id: str,
+    arch: Literal["amd64", "arm64"],
+    private_endpoint_configs: PrivateEndpointConfigs,
 ) -> AsyncGenerator[Application, None]:
     """The test charm that becomes active when valid relation data is given."""
     # The predefine inputs here can be trusted
@@ -140,7 +143,18 @@ async def test_charm_fixture(
     )
     logger.info("Deploying built test charm.")
     app_name = f"test-{test_id}"
-    app: Application = await model.deploy(f"./test_ubuntu-22.04-{arch}.charm", app_name)
+    app: Application = await model.deploy(
+        f"./test_ubuntu-22.04-{arch}.charm",
+        app_name,
+        config={
+            "openstack-auth-url": private_endpoint_configs["auth_url"],
+            "openstack-password": private_endpoint_configs["password"],
+            "openstack-project-domain-name": private_endpoint_configs["project_domain_name"],
+            "openstack-project-name": private_endpoint_configs["project_name"],
+            "openstack-user-domain-name": private_endpoint_configs["user_domain_name"],
+            "openstack-user-name": private_endpoint_configs["username"],
+        },
+    )
 
     yield app
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -314,7 +314,7 @@ async def app_fixture(
 ) -> AsyncGenerator[Application, None]:
     """The deployed application fixture."""
     config = {
-        APP_CHANNEL_CONFIG_NAME: "edge",
+        APP_CHANNEL_CONFIG_NAME: "test",
         BUILD_INTERVAL_CONFIG_NAME: 12,
         REVISION_HISTORY_LIMIT_CONFIG_NAME: 2,
         OPENSTACK_AUTH_URL_CONFIG_NAME: private_endpoint_configs["auth_url"],

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -114,7 +114,7 @@ async def model_fixture(
         assert ops_test.model is not None
         # Check if private endpoint Juju model is being used. If not, configure proxy.
         # Note that "testing" is the name of the default testing model in operator-workflows.
-        if ops_test.model.name == "testing":
+        if "test" in ops_test.model.name:
             # Set model proxy for the runners
             await ops_test.model.set_config(
                 {

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -339,9 +339,7 @@ async def app_fixture(
         config=config,
     )
     # This takes long due to having to wait for the machine to come up.
-    await test_configs.model.wait_for_idle(
-        apps=[app.name], wait_for_active=True, idle_period=30, timeout=60 * 30
-    )
+    await test_configs.model.wait_for_idle(apps=[app.name], idle_period=30, timeout=60 * 30)
 
     yield app
 

--- a/tests/integration/data/charm/charmcraft.yaml
+++ b/tests/integration/data/charm/charmcraft.yaml
@@ -48,6 +48,48 @@ config:
       type: string
       default: test
       description: test config option to satisfy charmcraft linter.
+    openstack-auth-url:
+      type: string
+      default: ""
+      description: |
+        The auth_url section of the clouds.yaml contents, used to authenticate the OpenStack \
+        client (e.g. http://my-openstack-deployment/openstack-keystone). See https://docs.\
+        openstack.org/python-openstackclient/queens/configuration/index.html for more information.
+    openstack-password:
+      type: string
+      default: ""
+      description: |
+        The password section of the clouds.yaml contents, used to authenticate the OpenStack \
+        client (e.g. myverysecurepassword). See https://docs.openstack.org/python-openstackclient/\
+        queens/configuration/index.html for more information.
+    openstack-project-domain-name:
+      type: string
+      default: ""
+      description: |
+        The project_domain_name section of the clouds.yaml contents, used to find the OpenStack
+        project-domain to use to store images. See https://docs.openstack.org/python-\
+        openstackclient/queens/configuration/index.html for more information.
+    openstack-project-name:
+      type: string
+      default: ""
+      description: |
+        The project_name section of the clouds.yaml contents, used to find the OpenStack project to
+        use to store images. See https://docs.openstack.org/python-openstackclient/queens/\
+        configuration/index.html for more information.
+    openstack-user-domain-name:
+      type: string
+      default: ""
+      description: |
+        The user_domain_name section of the clouds.yaml contents, used to find the OpenStack
+        user domain to authenticate the client. See https://docs.openstack.org/python-\
+        openstackclient/queens/configuration/index.html for more information.
+    openstack-user-name:
+      type: string
+      default: ""
+      description: |
+        The username section of the clouds.yaml contents, used to find the OpenStack user to \
+        authenticate the client. See https://docs.openstack.org/python-openstackclient/queens/\
+        configuration/index.html for more information.
 
 requires:
   image:

--- a/tests/integration/data/charm/src/charm.py
+++ b/tests/integration/data/charm/src/charm.py
@@ -32,6 +32,9 @@ class RelationCharm(ops.CharmBase):
         """
         super().__init__(*args)
         self.framework.observe(
+            self.on[IMAGE_RELATION].relation_joined, self._on_image_relation_joined
+        )
+        self.framework.observe(
             self.on[IMAGE_RELATION].relation_changed, self._on_image_relation_changed
         )
 

--- a/tests/integration/data/charm/src/charm.py
+++ b/tests/integration/data/charm/src/charm.py
@@ -44,6 +44,7 @@ class RelationCharm(ops.CharmBase):
         Args:
             event: The event fired when relation is joined.
         """
+        logger.info("Relation joined.")
         event.relation.data[self.unit].update(
             {
                 "auth_url": self.config["openstack-auth-url"],
@@ -54,6 +55,7 @@ class RelationCharm(ops.CharmBase):
                 "username": self.config["openstack-user-name"],
             }
         )
+        logger.info("Relation data updated.")
 
     def _on_image_relation_changed(self, event: ops.RelationChangedEvent):
         """Handle the image relation changed event.

--- a/tests/integration/data/charm/src/charm.py
+++ b/tests/integration/data/charm/src/charm.py
@@ -36,7 +36,7 @@ class RelationCharm(ops.CharmBase):
         )
 
     def _on_image_relation_joined(self, event: ops.RelationJoinedEvent):
-        """Handle the iamge relation joined event.
+        """Handle the image relation joined event.
 
         Args:
             event: The event fired when relation is joined.

--- a/tests/integration/data/charm/src/charm.py
+++ b/tests/integration/data/charm/src/charm.py
@@ -35,6 +35,23 @@ class RelationCharm(ops.CharmBase):
             self.on[IMAGE_RELATION].relation_changed, self._on_image_relation_changed
         )
 
+    def _on_image_relation_joined(self, event: ops.RelationJoinedEvent):
+        """Handle the iamge relation joined event.
+
+        Args:
+            event: The event fired when relation is joined.
+        """
+        event.relation.data[self.unit].update(
+            {
+                "auth_url": self.config["openstack-auth-url"],
+                "password": self.config["openstack-password"],
+                "project_domain_name": self.config["openstack-project-domain-name"],
+                "project_name": self.config["openstack-project-name"],
+                "user_domain_name": self.config["openstack-user-domain-name"],
+                "username": self.config["openstack-user-name"],
+            }
+        )
+
     def _on_image_relation_changed(self, event: ops.RelationChangedEvent):
         """Handle the image relation changed event.
 

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -73,7 +73,13 @@ def _configure_dockerhub_mirror(conn: SSHConnection, dockerhub_mirror: str | Non
     """
     if not dockerhub_mirror:
         return
-    command = f"""echo '{{ "registry-mirrors": ["{dockerhub_mirror}"] }}' | \
+    command = "sudo systemctl status docker --no-pager"
+    logger.info("Running command: %s", command)
+    result: Result = conn.run(command)
+    assert result.ok, "Failed to show docker status"
+
+    command = f"""sudo mkdir -p /etc/docker/ && \
+echo '{{ "registry-mirrors": ["{dockerhub_mirror}"] }}' | \
 sudo tee /etc/docker/daemon.json"""
     logger.info("Running command: %s", command)
     result: Result = conn.run(command)

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -63,6 +63,11 @@ EOF"""  # noqa: E501
     result = conn.run(command)
     assert result.ok, "Failed to configure iptable rules"
 
+    command = "sudo snap services aproxy"
+    logger.info("Running command: %s", command)
+    result = conn.run(command)
+    assert result.ok, "Failed to check aproxy status"
+
 
 def _configure_dockerhub_mirror(conn: SSHConnection, dockerhub_mirror: str | None):
     """Use dockerhub mirror if provided.

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -82,7 +82,7 @@ def _configure_dockerhub_mirror(conn: SSHConnection, dockerhub_mirror: str | Non
 echo '{{ "registry-mirrors": ["{dockerhub_mirror}"] }}' | \
 sudo tee /etc/docker/daemon.json"""
     logger.info("Running command: %s", command)
-    result: Result = conn.run(command)
+    result = conn.run(command)
     assert result.ok, "Failed to setup DockerHub mirror"
 
     command = "sudo systemctl daemon-reload"

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -100,6 +100,7 @@ TEST_RUNNER_COMMANDS = (
     Commands(
         name="file permission to /usr/local/bin (create)", command="touch /usr/local/bin/test_file"
     ),
+    Commands(name="proxy internet access test", command="curl google.com", retry=3),
     Commands(name="install microk8s", command="sudo snap install microk8s --classic", retry=3),
     # This is a special helper command to configure dockerhub registry if available.
     Commands(
@@ -177,7 +178,7 @@ async def test_image(
                 result: Result = ssh_connection.run(command.command, env=env if env else None)
             except invoke.exceptions.UnexpectedExit as exc:
                 logger.info(
-                    "Unexpected exception (retry attempt: %s): %s %s %s %s %s %s",
+                    "Unexpected exception (retry attempt: %s): %s %s %s %s %s",
                     attempt,
                     exc.reason,
                     exc.args,

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -34,7 +34,7 @@ async def test_image_relation(app: Application, test_charm: Application):
     """
     model: Model = app.model
     await model.integrate(app.name, test_charm.name)
-    await model.wait_for_idle([app.name, test_charm.name], wait_for_active=True, timeout=30 * 60)
+    await model.wait_for_idle([app.name], wait_for_active=True, timeout=30 * 60)
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -34,7 +34,7 @@ async def test_image_relation(app: Application, test_charm: Application):
     """
     model: Model = app.model
     await model.integrate(app.name, test_charm.name)
-    await model.wait_for_idle([app.name, test_charm.name], wait_for_active=True)
+    await model.wait_for_idle([app.name, test_charm.name], wait_for_active=True, timeout=30 * 60)
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -26,6 +26,18 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.mark.asyncio
+async def test_image_relation(app: Application, test_charm: Application):
+    """
+    arrange: An active charm and a test charm that becomes active when valid relation data is set.
+    act: When the relation is joined.
+    assert: The test charm becomes active due to proper relation data.
+    """
+    model: Model = app.model
+    await model.integrate(app.name, test_charm.name)
+    await model.wait_for_idle([app.name, test_charm.name], wait_for_active=True)
+
+
+@pytest.mark.asyncio
 async def test_build_image(
     app: Application, openstack_connection: Connection, dispatch_time: datetime
 ):
@@ -57,18 +69,6 @@ async def test_build_image(
         )
 
     await wait_for(image_created_from_dispatch, check_interval=30, timeout=60 * 30)
-
-
-@pytest.mark.asyncio
-async def test_image_relation(app: Application, test_charm: Application):
-    """
-    arrange: An active charm and a test charm that becomes active when valid relation data is set.
-    act: When the relation is joined.
-    assert: The test charm becomes active due to proper relation data.
-    """
-    model: Model = app.model
-    await model.integrate(app.name, test_charm.name)
-    await model.wait_for_idle([app.name, test_charm.name], wait_for_active=True)
 
 
 @dataclasses.dataclass

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -173,7 +173,14 @@ async def test_image(
         try:
             result: Result = ssh_connection.run(command.command, env=env if env else None)
         except invoke.exceptions.UnexpectedExit as exc:
-            logger.info("Unexpected exception: %s %s %s", exc.reason, exc.reason, exc.args)
+            logger.info(
+                "Unexpected exception: %s %s %s %s %s",
+                exc.reason,
+                exc.args,
+                exc.result.stdout,
+                exc.result.stderr,
+                exc.result.return_code,
+            )
             assert False
         logger.info("Command output: %s %s %s", result.return_code, result.stdout, result.stderr)
         assert result.ok

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -59,7 +59,11 @@ async def test_build_image(
             IMAGE_BASE=image_base, APP_NAME=app.name, ARCH=_get_supported_arch().value
         )
         images: list[Image] = openstack_connection.search_images(image_name)
-        logger.info("Image name: %s, Images: %s", image_name, images)
+        logger.info(
+            "Image name: %s, Images: %s",
+            image_name,
+            tuple((image.id, image.name, image.created_at) for image in images),
+        )
         # split logs, the image log is long and gets cut off.
         logger.info("Dispatch time: %s", dispatch_time)
         return any(

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -9,6 +9,7 @@ import dataclasses
 import logging
 from datetime import datetime, timezone
 
+import invoke.exceptions
 import pytest
 from fabric.connection import Connection as SSHConnection
 from fabric.runners import Result
@@ -169,6 +170,10 @@ async def test_image(
                 command=command.command, dockerhub_mirror=dockerhub_mirror
             )
         logger.info("Running test: %s", command.name)
-        result: Result = ssh_connection.run(command.command, env=env if env else None)
+        try:
+            result: Result = ssh_connection.run(command.command, env=env if env else None)
+        except invoke.exceptions.UnexpectedExit as exc:
+            logger.info("Unexpected exception: %s %s %s", exc.reason, exc.reason, exc.args)
+            assert False
         logger.info("Command output: %s %s %s", result.return_code, result.stdout, result.stderr)
         assert result.ok

--- a/tests/integration/types.py
+++ b/tests/integration/types.py
@@ -37,6 +37,8 @@ class SSHKey(typing.NamedTuple):
     private_key: Path
 
 
+# The following is a wrapper for test related data and is not a duplicate code.
+# pylint: disable=duplicate-code
 class PrivateEndpointConfigs(typing.TypedDict):
     """The Private endpoint configuration values.
 
@@ -59,6 +61,9 @@ class PrivateEndpointConfigs(typing.TypedDict):
     user_domain_name: str
     username: str
     region_name: str
+
+
+# pylint: enable=duplicate-code
 
 
 class TestConfigs(typing.NamedTuple):

--- a/tests/unit/test_builder.py
+++ b/tests/unit/test_builder.py
@@ -286,7 +286,7 @@ def test_run_error(monkeypatch: pytest.MonkeyPatch):
     )
 
     with pytest.raises(builder.BuilderRunError) as exc:
-        builder.run(config=testconfig)
+        builder.run(config=testconfig, proxy=None)
 
     assert "Failed to spawn process" in str(exc.getrepr())
 
@@ -314,7 +314,7 @@ def test_run_output_error(
     )
 
     with pytest.raises(builder.BuilderRunError) as exc:
-        builder.run(config=testconfig)
+        builder.run(config=testconfig, proxy=None)
 
     assert "Unexpected output" in str(exc)
 
@@ -355,7 +355,7 @@ def test_run(
         runner_version=runner_version,
     )
 
-    builder.run(config=testconfig)
+    builder.run(config=testconfig, proxy=MagicMock())
 
     check_output_mock.assert_called_once()
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -127,6 +127,7 @@ def test__on_install(monkeypatch: pytest.MonkeyPatch, charm: GithubRunnerImageBu
     monkeypatch.setattr(image, "Observer", MagicMock())
     monkeypatch.setattr(proxy, "setup", MagicMock())
     monkeypatch.setattr(proxy, "configure_aproxy", MagicMock())
+    monkeypatch.setattr(builder, "install_clouds_yaml", MagicMock())
     monkeypatch.setattr(builder, "initialize", (setup_mock := MagicMock()))
 
     charm._on_install(MagicMock())

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -29,6 +29,59 @@ def charm_fixture():
     return charm
 
 
+@pytest.fixture(name="patch_builder_init_config_from_charm", scope="function")
+def patch_builder_init_config_from_charm(monkeypatch: pytest.MonkeyPatch):
+    """Fixture to patch builder init config."""
+    monkeypatch.setattr(
+        state.BuilderInitConfig,
+        "from_charm",
+        MagicMock(
+            return_value=state.BuilderInitConfig(
+                channel=MagicMock(),
+                external_build=True,
+                interval=1,
+                run_config=state.BuilderRunConfig(
+                    arch=MagicMock(),
+                    base=MagicMock(),
+                    cloud_config=state.OpenstackCloudsConfig(
+                        clouds={
+                            state.UPLOAD_CLOUD_NAME: state._CloudsConfig(
+                                auth=MagicMock(), region_name="test"
+                            )
+                        }
+                    ),
+                    external_build_config=MagicMock(),
+                    num_revisions=1,
+                    runner_version="test-version",
+                ),
+                unit_name="test-unit",
+            )
+        ),
+    )
+
+
+@pytest.mark.parametrize(
+    "hook",
+    [
+        pytest.param("_on_config_changed", id="config_changed"),
+        pytest.param("_on_run_action", id="run_action"),
+    ],
+)
+def test_block_on_image_relation_not_ready(
+    monkeypatch: pytest.MonkeyPatch, charm: GithubRunnerImageBuilderCharm, hook: str
+):
+    """
+    arrange: given hooks that should not run build when image relation is not yet ready.
+    act: when the hook is called.
+    assert: the charm falls into BlockedStatus.
+    """
+    monkeypatch.setattr(state.BuilderInitConfig, "from_charm", MagicMock())
+    monkeypatch.setattr(state.BuilderRunConfig, "from_charm", MagicMock())
+    getattr(charm, hook)(MagicMock())
+
+    assert charm.unit.status == ops.BlockedStatus(f"{state.IMAGE_RELATION} integration required.")
+
+
 @pytest.mark.parametrize(
     "hook",
     [
@@ -74,16 +127,14 @@ def test__on_install(monkeypatch: pytest.MonkeyPatch, charm: GithubRunnerImageBu
     monkeypatch.setattr(proxy, "setup", MagicMock())
     monkeypatch.setattr(proxy, "configure_aproxy", MagicMock())
     monkeypatch.setattr(builder, "initialize", (setup_mock := MagicMock()))
-    monkeypatch.setattr(builder, "run", (run_mock := MagicMock()))
-    monkeypatch.setattr(builder, "upgrade_app", (run_mock := MagicMock()))
 
     charm._on_install(MagicMock())
 
     setup_mock.assert_called_once()
-    run_mock.assert_called_once()
-    assert charm.unit.status == ops.ActiveStatus()
+    assert charm.unit.status == ops.ActiveStatus("Waiting for first image.")
 
 
+@pytest.mark.usefixtures("patch_builder_init_config_from_charm")
 @pytest.mark.parametrize(
     "configure_cron",
     [
@@ -99,7 +150,6 @@ def test__on_config_changed(
     act: when _on_config_changed is called.
     assert: charm is in active status.
     """
-    monkeypatch.setattr(state.BuilderInitConfig, "from_charm", MagicMock())
     monkeypatch.setattr(state.BuilderRunConfig, "from_charm", MagicMock())
     monkeypatch.setattr(
         image, "Observer", MagicMock(return_value=(image_observer_mock := MagicMock()))
@@ -114,3 +164,82 @@ def test__on_config_changed(
     charm._on_config_changed(MagicMock())
 
     assert charm.unit.status == ops.ActiveStatus()
+
+
+@pytest.mark.usefixtures("patch_builder_init_config_from_charm")
+def test__on_run_action(charm: GithubRunnerImageBuilderCharm):
+    """
+    arrange: given a mocked functions of _on_run_action.
+    act: when _on_run_action is called.
+    assert: subfunctions are called.
+    """
+    charm._run = (run_mock := MagicMock())
+
+    charm._on_run_action(MagicMock())
+
+    run_mock.assert_called()
+
+
+@pytest.mark.parametrize(
+    "config, expected_return",
+    [
+        pytest.param(
+            state.BuilderRunConfig(
+                arch=state.Arch.ARM64,
+                base=state.BaseImage.JAMMY,
+                cloud_config=state.OpenstackCloudsConfig(clouds={}),
+                external_build_config=None,
+                num_revisions=1,
+                runner_version="test",
+            ),
+            False,
+            id="missiong integration",
+        ),
+        pytest.param(
+            state.BuilderRunConfig(
+                arch=state.Arch.ARM64,
+                base=state.BaseImage.JAMMY,
+                cloud_config=state.OpenstackCloudsConfig(
+                    clouds={
+                        state.UPLOAD_CLOUD_NAME: state._CloudsConfig(auth=None, region_name="test")
+                    }
+                ),
+                external_build_config=None,
+                num_revisions=1,
+                runner_version="test",
+            ),
+            False,
+            id="waiting integration data",
+        ),
+        pytest.param(
+            state.BuilderRunConfig(
+                arch=state.Arch.ARM64,
+                base=state.BaseImage.JAMMY,
+                cloud_config=state.OpenstackCloudsConfig(
+                    clouds={
+                        state.UPLOAD_CLOUD_NAME: state._CloudsConfig(
+                            auth=state._CloudsAuthConfig(auth_url="test-auth-url"),
+                            region_name="test",
+                        )
+                    }
+                ),
+                external_build_config=None,
+                num_revisions=1,
+                runner_version="test",
+            ),
+            True,
+            id="integration ready",
+        ),
+    ],
+)
+def test__is_image_relation_ready_set_status(
+    charm: GithubRunnerImageBuilderCharm,
+    config: state.BuilderRunConfig,
+    expected_return: bool,
+):
+    """
+    arrange: given builder run config state.
+    act: when _is_image_relation_ready_set_status is called.
+    assert: expected boolean value is returned.
+    """
+    assert charm._is_image_relation_ready_set_status(config=config) == expected_return

--- a/tests/unit/test_image.py
+++ b/tests/unit/test_image.py
@@ -65,8 +65,7 @@ def test_update_relation_data(monkeypatch: pytest.MonkeyPatch):
     """
     monkeypatch.setattr(state.BuilderRunConfig, "from_charm", MagicMock())
     observer = image.Observer(MagicMock())
-    # Harness doesn't understand latest charmcraft.yaml, so it can't be used here.
-    observer.model.relations = {image.IMAGE_RELATION: [(relation := MagicMock())]}
+    observer.model.relations = {state.IMAGE_RELATION: [(relation := MagicMock())]}
 
     observer.update_image_data(
         image_id=(test_id := "test-image-id"), arch=state.Arch.ARM64, base=state.BaseImage.JAMMY

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -275,7 +275,6 @@ def test_builder_run_config(monkeypatch: pytest.MonkeyPatch):
                             "username": "username",
                         }
                     },
-                    state.UPLOAD_CLOUD_NAME: {"auth": None},
                 }
             },
             external_build_config=None,
@@ -639,9 +638,7 @@ def test_github_runner_openstack_config_from_charm_no_unit_data():
     relation_mock.units = [(relation_unit_mock := MagicMock())]
     relation_mock.data = {relation_unit_mock: None}
 
-    assert state.GitHubRunnerOpenStackConfig.from_charm(
-        charm=mock_charm
-    ) == state.GitHubRunnerOpenStackConfig(auth=None)
+    assert state.GitHubRunnerOpenStackConfig.from_charm(charm=mock_charm) is None
 
 
 def test_github_runner_openstack_config_from_charm():
@@ -653,7 +650,18 @@ def test_github_runner_openstack_config_from_charm():
     mock_charm = MagicMock()
     mock_charm.model.relations = {state.IMAGE_RELATION: [(relation_mock := MagicMock())]}
     relation_mock.units = [(relation_unit_mock := MagicMock())]
-    relation_mock.data = {relation_unit_mock: (mock_data := MagicMock())}
+    relation_mock.data = {
+        relation_unit_mock: (
+            mock_data := {
+                "auth_url": "test",
+                "password": "test",
+                "project_domain_name": "test",
+                "project_name": "test",
+                "user_domain_name": "test",
+                "username": "test",
+            }
+        )
+    }
 
     assert state.GitHubRunnerOpenStackConfig.from_charm(
         charm=mock_charm

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -274,7 +274,8 @@ def test_builder_run_config(monkeypatch: pytest.MonkeyPatch):
                             "user_domain_name": "user_domain_name",
                             "username": "username",
                         }
-                    }
+                    },
+                    state.UPLOAD_CLOUD_NAME: {"auth": None},
                 }
             },
             external_build_config=None,
@@ -479,6 +480,78 @@ def test__parse_openstack_clouds_config_invalid(missing_config: str):
     assert "Please supply all OpenStack configurations." in str(exc)
 
 
+# mypy doesn't understand walrus operator here
+# pylint: disable=undefined-variable,unused-variable
+@pytest.mark.parametrize(
+    "openstack_config_from_relation, expected_config",
+    [
+        pytest.param(
+            None,
+            state.OpenstackCloudsConfig(
+                clouds={
+                    state.CLOUD_NAME: state._CloudsConfig(
+                        auth=state._CloudsAuthConfig(
+                            auth_url="http://testing-auth/keystone",
+                            # this is referring to hard-coded factory value since factory object
+                            # is not initialized and it is not a real secret
+                            password="testingvalue",  # nosec
+                            project_domain_name="project_domain_name",
+                            project_name="project_name",
+                            user_domain_name="user_domain_name",
+                            username="username",
+                        )
+                    ),
+                }
+            ),
+            id="None",
+        ),
+        pytest.param(
+            (relation_mock_config := MagicMock()),
+            state.OpenstackCloudsConfig(
+                clouds={
+                    state.CLOUD_NAME: state._CloudsConfig(
+                        auth=state._CloudsAuthConfig(
+                            auth_url="http://testing-auth/keystone",
+                            # this is referring to hard-coded factory value since factory object
+                            # is not initialized and it is not a real secret
+                            password="testingvalue",  # nosec
+                            project_domain_name="project_domain_name",
+                            project_name="project_name",
+                            user_domain_name="user_domain_name",
+                            username="username",
+                        )
+                    ),
+                    state.UPLOAD_CLOUD_NAME: state._CloudsConfig(auth=relation_mock_config.auth),
+                }
+            ),
+            id="mock data",
+        ),
+    ],
+)
+def test__parse_openstack_clouds_config(
+    monkeypatch: pytest.MonkeyPatch,
+    openstack_config_from_relation: state.GitHubRunnerOpenStackConfig | None,
+    expected_config: state.OpenstackCloudsConfig,
+):
+    """
+    arrange: given openstack related config options and monkeypatched GitHubRunnerOpenStackConfig.
+    act: when _parse_openstack_clouds_config is called.
+    assert: expected clouds_config is returned.
+    """
+    monkeypatch.setattr(
+        state.GitHubRunnerOpenStackConfig,
+        "from_charm",
+        MagicMock(return_value=openstack_config_from_relation),
+    )
+    charm = MockCharmFactory()
+
+    cloud_config = state._parse_openstack_clouds_config(charm=charm)
+    assert cloud_config == expected_config
+
+
+# pylint: enable=undefined-variable,unused-variable
+
+
 def test_builder_app_channel_from_charm_error():
     """
     arrange: given an invalid charm app channel config.
@@ -540,3 +613,57 @@ def test_builder_init_config_invalid(
         state.BuilderInitConfig.from_charm(charm)
 
     assert expected_message in str(exc.getrepr())
+
+
+def test_github_runner_openstack_config_from_charm_no_relation_units():
+    """
+    arrange: given a github runner image relation with no relations.
+    act: when GitHubRunnerOpenStackConfig.from_charm is called.
+    assert: None is returned.
+    """
+    mock_charm = MagicMock()
+    mock_charm.model.relations = {state.IMAGE_RELATION: [(mock_relation := MagicMock())]}
+    mock_relation.units = None
+
+    assert state.GitHubRunnerOpenStackConfig.from_charm(charm=mock_charm) is None
+
+
+def test_github_runner_openstack_config_from_charm_no_unit_data():
+    """
+    arrange: given a github runner image relation with no relation data.
+    act: when GitHubRunnerOpenStackConfig.from_charm is called.
+    assert: None is returned.
+    """
+    mock_charm = MagicMock()
+    mock_charm.model.relations = {state.IMAGE_RELATION: [(relation_mock := MagicMock())]}
+    relation_mock.units = [(relation_unit_mock := MagicMock())]
+    relation_mock.data = {relation_unit_mock: None}
+
+    assert state.GitHubRunnerOpenStackConfig.from_charm(
+        charm=mock_charm
+    ) == state.GitHubRunnerOpenStackConfig(auth=None)
+
+
+def test_github_runner_openstack_config_from_charm():
+    """
+    arrange: given a github runner image relation.
+    act: when GitHubRunnerOpenStackConfig.from_charm is called.
+    assert: expected GitHubRunnerOpenStackConfig is returned.
+    """
+    mock_charm = MagicMock()
+    mock_charm.model.relations = {state.IMAGE_RELATION: [(relation_mock := MagicMock())]}
+    relation_mock.units = [(relation_unit_mock := MagicMock())]
+    relation_mock.data = {relation_unit_mock: (mock_data := MagicMock())}
+
+    assert state.GitHubRunnerOpenStackConfig.from_charm(
+        charm=mock_charm
+    ) == state.GitHubRunnerOpenStackConfig(
+        auth=state._CloudsAuthConfig(
+            auth_url=mock_data["auth_url"],
+            password=mock_data["password"],
+            project_domain_name=mock_data["project_domain_name"],
+            project_name=mock_data["project_name"],
+            user_domain_name=mock_data["user_domain_name"],
+            username=mock_data["username"],
+        )
+    )


### PR DESCRIPTION
Applicable spec: N?A

### Overview

- Runs the image builder in external OpenStack VM mode

### Rationale

- Switch to external VM build to enable bootstrapped juju (snaps: microk8s juju lxd).

### Juju Events Changes

- On image relation joined, Github runner will provide OpenStack credentials for it to upload the final image to.

### Module Changes

- charm.py - now processes image builder joined event
- state.py - processes image builder relation data
- builder.py - adds flag to run external build

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
