### PR TITLE
feat: multiple cloud image uploads

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 ops == 2.14.0
 openstacksdk == 3.1.0
+pydantic == 2.9.1

--- a/src-docs/builder.py.md
+++ b/src-docs/builder.py.md
@@ -38,7 +38,7 @@ Configure the host machine to build images.
 
 ---
 
-<a href="../src/builder.py#L119"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/builder.py#L127"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `install_clouds_yaml`
 
@@ -57,7 +57,7 @@ Install clouds.yaml for Openstack used by the image builder.
 
 ---
 
-<a href="../src/builder.py#L133"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/builder.py#L141"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `configure_cron`
 
@@ -82,7 +82,7 @@ Configure cron to run builder.
 
 ---
 
-<a href="../src/builder.py#L189"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/builder.py#L197"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `run`
 
@@ -113,7 +113,7 @@ Run a build immediately.
 
 ---
 
-<a href="../src/builder.py#L263"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/builder.py#L271"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `get_latest_image`
 
@@ -145,7 +145,7 @@ Fetch the latest image build ID.
 
 ---
 
-<a href="../src/builder.py#L299"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/builder.py#L315"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `upgrade_app`
 

--- a/src-docs/builder.py.md
+++ b/src-docs/builder.py.md
@@ -13,7 +13,7 @@ Module for interacting with qemu image builder.
 
 ---
 
-<a href="../src/builder.py#L48"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/builder.py#L49"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `initialize`
 
@@ -38,12 +38,12 @@ Configure the host machine to build images.
 
 ---
 
-<a href="../src/builder.py#L118"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/builder.py#L119"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `install_clouds_yaml`
 
 ```python
-install_clouds_yaml(cloud_config: dict) → None
+install_clouds_yaml(cloud_config: OpenstackCloudsConfig) → None
 ```
 
 Install clouds.yaml for Openstack used by the image builder. 
@@ -57,7 +57,7 @@ Install clouds.yaml for Openstack used by the image builder.
 
 ---
 
-<a href="../src/builder.py#L131"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/builder.py#L133"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `configure_cron`
 
@@ -82,12 +82,12 @@ Configure cron to run builder.
 
 ---
 
-<a href="../src/builder.py#L174"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/builder.py#L189"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `run`
 
 ```python
-run(config: BuilderRunConfig, proxy: ProxyConfig | None) → str
+run(config: BuilderRunConfig, proxy: ProxyConfig | None) → list[CloudImage]
 ```
 
 Run a build immediately. 
@@ -113,7 +113,7 @@ Run a build immediately.
 
 ---
 
-<a href="../src/builder.py#L240"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/builder.py#L263"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `get_latest_image`
 
@@ -145,7 +145,7 @@ Fetch the latest image build ID.
 
 ---
 
-<a href="../src/builder.py#L276"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/builder.py#L299"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `upgrade_app`
 
@@ -160,5 +160,21 @@ Upgrade the application if newer version is available.
 **Raises:**
  
  - <b>`UpgradeApplicationError`</b>:  If there was an error upgrading the application. 
+
+
+---
+
+## <kbd>class</kbd> `CloudImage`
+The cloud ID to uploaded image ID pair. 
+
+
+
+**Attributes:**
+ 
+ - <b>`cloud_id`</b>:  The cloud ID that the image was uploaded to. 
+ - <b>`image_id`</b>:  The uploaded image ID. 
+
+
+
 
 

--- a/src-docs/charm.py.md
+++ b/src-docs/charm.py.md
@@ -69,7 +69,7 @@ Unit that this execution is responsible for.
 
 ---
 
-<a href="../src/charm.py#L125"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm.py#L120"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `update_status`
 

--- a/src-docs/image.py.md
+++ b/src-docs/image.py.md
@@ -55,21 +55,25 @@ Shortcut for more simple access the model.
 
 ---
 
-<a href="../src/image.py#L60"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/image.py#L73"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `update_image_data`
 
 ```python
-update_image_data(image_id: str, arch: Arch, base: BaseImage) → None
+update_image_data(
+    cloud_image_ids: list[CloudImage],
+    arch: Arch,
+    base: BaseImage
+) → None
 ```
 
-Update the relation data if exists. 
+Update the relation data if image exists for according cloud supplied by the relation         data. 
 
 
 
 **Args:**
  
- - <b>`image_id`</b>:  The latest image ID to propagate. 
+ - <b>`cloud_image_ids`</b>:  The cloud id and image id pairs to propagate via relation data. 
  - <b>`arch`</b>:  The architecture in which the image was built for. 
  - <b>`base`</b>:  The OS base image. 
 

--- a/src-docs/image.py.md
+++ b/src-docs/image.py.md
@@ -55,7 +55,7 @@ Shortcut for more simple access the model.
 
 ---
 
-<a href="../src/image.py#L73"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/image.py#L77"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `update_image_data`
 

--- a/src-docs/image.py.md
+++ b/src-docs/image.py.md
@@ -55,7 +55,7 @@ Shortcut for more simple access the model.
 
 ---
 
-<a href="../src/image.py#L77"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/image.py#L79"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `update_image_data`
 
@@ -67,7 +67,7 @@ update_image_data(
 ) → None
 ```
 
-Update the relation data if image exists for according cloud supplied by the relation         data. 
+Update relation data for each cloud coming from image requires side of relation. 
 
 
 

--- a/src-docs/state.py.md
+++ b/src-docs/state.py.md
@@ -10,7 +10,6 @@ Module for interacting with charm state and configurations.
 - **ARCHITECTURES_ARM64**
 - **ARCHITECTURES_X86**
 - **CLOUD_NAME**
-- **UPLOAD_CLOUD_NAME**
 - **LTS_IMAGE_VERSION_TAG_MAP**
 - **APP_CHANNEL_CONFIG_NAME**
 - **BASE_IMAGE_CONFIG_NAME**
@@ -149,7 +148,7 @@ The image builder setup config.
 
 ---
 
-<a href="../src/state.py#L509"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/state.py#L593"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `from_charm`
 
@@ -188,8 +187,9 @@ Configurations for running builder periodically.
  
  - <b>`arch`</b>:  The machine architecture of the image to build with. 
  - <b>`base`</b>:  Ubuntu OS image to build from. 
- - <b>`cloud_config`</b>:  The Openstack clouds.yaml passed as charm config. 
- - <b>`cloud_name`</b>:  The Openstack cloud name to connect to from clouds.yaml. 
+ - <b>`cloud_config`</b>:  The OpenStack clouds.yaml passed as charm config. 
+ - <b>`cloud_name`</b>:  The OpenStack cloud name to connect to from clouds.yaml. 
+ - <b>`upload_cloud_ids`</b>:  The OpenStack cloud ids to connect to, where the image should be             made available. 
  - <b>`external_build_config`</b>:  The external builder configuration values. 
  - <b>`num_revisions`</b>:  Number of images to keep before deletion. 
  - <b>`runner_version`</b>:  The GitHub runner version to embed in the image. Latest version if empty. 
@@ -201,11 +201,17 @@ Configurations for running builder periodically.
 
 The cloud name from cloud_config. 
 
+---
+
+#### <kbd>property</kbd> upload_cloud_ids
+
+The cloud name from cloud_config. 
+
 
 
 ---
 
-<a href="../src/state.py#L276"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/state.py#L334"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `from_charm`
 
@@ -291,6 +297,88 @@ Initialize a new instance of the CharmConfigInvalidError exception.
 
 ---
 
+## <kbd>class</kbd> `CloudsAuthConfig`
+Clouds.yaml authentication parameters. 
+
+
+
+**Attributes:**
+ 
+ - <b>`auth_url`</b>:  OpenStack authentication URL (keystone). 
+ - <b>`password`</b>:  OpenStack project user password. 
+ - <b>`project_domain_name`</b>:  OpenStack project domain name. 
+ - <b>`project_name`</b>:  OpenStack project name. 
+ - <b>`user_domain_name`</b>:  OpenStack user domain name. 
+ - <b>`username`</b>:  The OpenStack user name for given project. 
+
+
+---
+
+#### <kbd>property</kbd> model_extra
+
+Get extra fields set during validation. 
+
+
+
+**Returns:**
+  A dictionary of extra fields, or `None` if `config.extra` is not set to `"allow"`. 
+
+---
+
+#### <kbd>property</kbd> model_fields_set
+
+Returns the set of fields that have been explicitly set on this model instance. 
+
+
+
+**Returns:**
+  A set of strings representing the fields that have been set,  i.e. that were not filled from defaults. 
+
+
+
+---
+
+<a href="../src/state.py#L243"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+### <kbd>classmethod</kbd> `from_unit_relation_data`
+
+```python
+from_unit_relation_data(data: RelationDataContent) → CloudsAuthConfig | None
+```
+
+Get auth data from unit relation data. 
+
+
+
+**Args:**
+ 
+ - <b>`data`</b>:  The unit relation data. 
+
+
+
+**Returns:**
+ CloudsAuthConfig if all required relation data are available, None otherwise. 
+
+---
+
+<a href="../src/state.py#L235"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+### <kbd>function</kbd> `get_id`
+
+```python
+get_id() → str
+```
+
+Get unique cloud configuration ID. 
+
+
+
+**Returns:**
+  The unique cloud configuration ID. 
+
+
+---
+
 ## <kbd>class</kbd> `ExternalBuildConfig`
 Configurations for external builder VMs. 
 
@@ -330,44 +418,6 @@ Initialize build configuration from current charm instance.
 
 ---
 
-## <kbd>class</kbd> `GitHubRunnerOpenStackConfig`
-The OpenStack cloud authentication data. 
-
-
-
-**Attributes:**
- 
- - <b>`auth`</b>:  The cloud authentication data. 
-
-
-
-
----
-
-<a href="../src/state.py#L549"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
-
-### <kbd>classmethod</kbd> `from_charm`
-
-```python
-from_charm(charm: CharmBase) → GitHubRunnerOpenStackConfig | None
-```
-
-Get the Github runner's OpenStack configuration from integratiotn data. 
-
-
-
-**Args:**
- 
- - <b>`charm`</b>:  The running charm instance. 
-
-
-
-**Returns:**
- GitHubRunnerOpenStackConfig if it exists on the relation. 
-
-
----
-
 ## <kbd>class</kbd> `InvalidCloudConfigError`
 Represents an error with openstack cloud config. 
 
@@ -386,6 +436,28 @@ The Openstack clouds.yaml configuration mapping.
  
  - <b>`clouds`</b>:  The mapping of cloud to cloud configuration values. 
 
+
+---
+
+#### <kbd>property</kbd> model_extra
+
+Get extra fields set during validation. 
+
+
+
+**Returns:**
+  A dictionary of extra fields, or `None` if `config.extra` is not set to `"allow"`. 
+
+---
+
+#### <kbd>property</kbd> model_fields_set
+
+Returns the set of fields that have been explicitly set on this model instance. 
+
+
+
+**Returns:**
+  A set of strings representing the fields that have been set,  i.e. that were not filled from defaults. 
 
 
 

--- a/src-docs/state.py.md
+++ b/src-docs/state.py.md
@@ -148,7 +148,7 @@ The image builder setup config.
 
 ---
 
-<a href="../src/state.py#L593"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/state.py#L594"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `from_charm`
 
@@ -211,7 +211,7 @@ The cloud name from cloud_config.
 
 ---
 
-<a href="../src/state.py#L334"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/state.py#L335"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `from_charm`
 

--- a/src/builder.py
+++ b/src/builder.py
@@ -3,6 +3,7 @@
 
 """Module for interacting with qemu image builder."""
 
+import dataclasses
 import logging
 import os
 
@@ -115,17 +116,18 @@ def _initialize_image_builder(init_config: state.BuilderInitConfig) -> None:
         raise ImageBuilderInitializeError from exc
 
 
-def install_clouds_yaml(cloud_config: dict) -> None:
+def install_clouds_yaml(cloud_config: state.OpenstackCloudsConfig) -> None:
     """Install clouds.yaml for Openstack used by the image builder.
 
     Args:
         cloud_config: The contents of clouds.yaml parsed as dict.
     """
+    cloud_config_dict = cloud_config.model_dump()
     if not OPENSTACK_CLOUDS_YAML_PATH.exists():
-        OPENSTACK_CLOUDS_YAML_PATH.write_text(yaml.safe_dump(cloud_config), encoding="utf-8")
+        OPENSTACK_CLOUDS_YAML_PATH.write_text(yaml.safe_dump(cloud_config_dict), encoding="utf-8")
         return
-    if yaml.safe_load(OPENSTACK_CLOUDS_YAML_PATH.read_text(encoding="utf-8")) != cloud_config:
-        OPENSTACK_CLOUDS_YAML_PATH.write_text(yaml.safe_dump(cloud_config), encoding="utf-8")
+    if yaml.safe_load(OPENSTACK_CLOUDS_YAML_PATH.read_text(encoding="utf-8")) != cloud_config_dict:
+        OPENSTACK_CLOUDS_YAML_PATH.write_text(yaml.safe_dump(cloud_config_dict), encoding="utf-8")
 
 
 def configure_cron(unit_name: str, interval: int) -> bool:
@@ -171,7 +173,20 @@ def _should_configure_cron(cron_contents: str) -> bool:
     return cron_contents != CRON_BUILD_SCHEDULE_PATH.read_text(encoding="utf-8")
 
 
-def run(config: state.BuilderRunConfig, proxy: state.ProxyConfig | None) -> str:
+@dataclasses.dataclass
+class CloudImage:
+    """The cloud ID to uploaded image ID pair.
+
+    Attributes:
+        cloud_id: The cloud ID that the image was uploaded to.
+        image_id: The uploaded image ID.
+    """
+
+    cloud_id: str
+    image_id: str
+
+
+def run(config: state.BuilderRunConfig, proxy: state.ProxyConfig | None) -> list[CloudImage]:
     """Run a build immediately.
 
     Args:
@@ -213,8 +228,8 @@ def run(config: state.BuilderRunConfig, proxy: state.ProxyConfig | None) -> str:
                     config.external_build_config.flavor,
                     "--network",
                     config.external_build_config.network,
-                    "--upload-cloud",
-                    state.UPLOAD_CLOUD_NAME,
+                    "--upload-clouds",
+                    ",".join(config.upload_cloud_ids),
                 ]
             )
         if proxy:
@@ -231,8 +246,16 @@ def run(config: state.BuilderRunConfig, proxy: state.ProxyConfig | None) -> str:
         )
         if config.external_build_config and "Image build success" not in stdout:
             raise BuilderRunError(f"Unexpected output: {stdout}")
-        # The return value of the CLI is "Image build success:\n<image-id>"
-        return stdout.split()[-1]
+        # The return value of the CLI is "Image build success:\n<comma-separated-image-ids>"
+        return list(
+            CloudImage(image_id=image_id, cloud_id=cloud_id)
+            for (cloud_id, image_id) in zip(config.upload_cloud_ids, stdout.split()[-1].split(","))
+        )
+    except subprocess.CalledProcessError as exc:
+        logger.error(
+            "Image build failed, code: %s, out: %s, err: %s", exc.stderr, exc.stdout, exc.stderr
+        )
+        raise BuilderRunError from exc
     except subprocess.SubprocessError as exc:
         raise BuilderRunError from exc
 

--- a/src/builder.py
+++ b/src/builder.py
@@ -112,6 +112,14 @@ def _initialize_image_builder(init_config: state.BuilderInitConfig) -> None:
             timeout=10 * 60,
             env=os.environ,
         )  # nosec: B603
+    except subprocess.CalledProcessError as exc:
+        logger.error(
+            "Failed to initialize builder, code: %s, out: %s, err: %s",
+            exc.returncode,
+            exc.stdout,
+            exc.stderr,
+        )
+        raise ImageBuilderInitializeError from exc
     except subprocess.SubprocessError as exc:
         raise ImageBuilderInitializeError from exc
 
@@ -292,6 +300,14 @@ def get_latest_image(arch: state.Arch, base: state.BaseImage, cloud_name: str) -
             encoding="utf-8",
         )  # nosec: B603
         return image_id
+    except subprocess.CalledProcessError as exc:
+        logger.error(
+            "Get latest id failed, code: %s, out: %s, err: %s",
+            exc.returncode,
+            exc.stdout,
+            exc.stderr,
+        )
+        raise GetLatestImageError from exc
     except subprocess.SubprocessError as exc:
         raise GetLatestImageError from exc
 
@@ -305,6 +321,7 @@ def upgrade_app() -> None:
     try:
         subprocess.run(  # nosec: B603
             [
+                "/usr/bin/run-one",
                 "/usr/bin/pipx",
                 "upgrade",
                 "github-runner-image-builder",
@@ -313,5 +330,13 @@ def upgrade_app() -> None:
             check=True,
             user=UBUNTU_USER,
         )
+    except subprocess.CalledProcessError as exc:
+        logger.error(
+            "Pipx upgrade failed, code: %s, out: %s, err: %s",
+            exc.returncode,
+            exc.stdout,
+            exc.stderr,
+        )
+        raise UpgradeApplicationError from exc
     except subprocess.SubprocessError as exc:
         raise UpgradeApplicationError from exc

--- a/src/image.py
+++ b/src/image.py
@@ -44,13 +44,26 @@ class Observer(ops.Object):
         )
 
     @charm_utils.block_if_invalid_config(defer=False)
-    def _on_image_relation_joined(self, _: ops.RelationJoinedEvent) -> None:
-        """Handle the image relation joined event."""
+    def _on_image_relation_joined(self, event: ops.RelationJoinedEvent) -> None:
+        """Handle the image relation joined event.
+
+        Args:
+            event: The event emitted when a relation is joined.
+        """
         build_config = state.BuilderRunConfig.from_charm(charm=self.charm)
+        if not build_config.upload_cloud_ids:
+            self.model.unit.status = ops.WaitingStatus("Waiting for relation data.")
+            return
+        unit_cloud_auth_config = state.CloudsAuthConfig.from_unit_relation_data(
+            data=event.relation.data[event.unit]
+        )
+        if not unit_cloud_auth_config:
+            logger.warning("Unit relation data not yet ready.")
+            return
         image_id = builder.get_latest_image(
             arch=build_config.arch,
             base=build_config.base,
-            cloud_name=build_config.cloud_name,
+            cloud_name=unit_cloud_auth_config.get_id(),
         )
         if not image_id:
             logger.warning("Image not yet ready.")
@@ -59,18 +72,38 @@ class Observer(ops.Object):
 
     def update_image_data(
         self,
-        image_id: str,
+        cloud_image_ids: list[builder.CloudImage],
         arch: state.Arch,
         base: state.BaseImage,
     ) -> None:
-        """Update the relation data if exists.
+        """Update the relation data if image exists for according cloud supplied by the relation \
+        data.
 
         Args:
-            image_id: The latest image ID to propagate.
+            cloud_image_ids: The cloud id and image id pairs to propagate via relation data.
             arch: The architecture in which the image was built for.
             base: The OS base image.
         """
+        cloud_id_to_image_id = {
+            cloud_image.cloud_id: cloud_image.image_id for cloud_image in cloud_image_ids
+        }
         for relation in self.model.relations[state.IMAGE_RELATION]:
-            relation.data[self.model.unit].update(
-                ImageRelationData(id=image_id, tags=",".join((arch.value, base.value)))
-            )
+            for unit in relation.units:
+                unit_auth_data = state.CloudsAuthConfig.from_unit_relation_data(
+                    data=relation.data[unit]
+                )
+                if (
+                    not unit_auth_data
+                    or (cloud_id := unit_auth_data.get_id()) not in cloud_id_to_image_id
+                ):
+                    logger.warning("Cloud auth data not found in relation with %s", unit.name)
+                    continue
+                relation.data[self.model.unit].update(
+                    ImageRelationData(
+                        id=cloud_id_to_image_id[cloud_id],
+                        tags=",".join((arch.value, base.value)),
+                    )
+                )
+                # the relation data update is required only once per relation since every units in
+                # the relation share the same OpenStack cloud credentials.
+                break

--- a/src/state.py
+++ b/src/state.py
@@ -261,6 +261,7 @@ class CloudsAuthConfig(pydantic.BaseModel):
                 "username",
             )
         ):
+            logger.info("Required relation data not yet set.")
             return None
         return cls(
             auth_url=data["auth_url"],

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -47,7 +47,7 @@ from state import (
     REVISION_HISTORY_LIMIT_CONFIG_NAME,
     _get_supported_arch,
 )
-from tests.integration.helpers import wait_for_valid_connection
+from tests.integration.helpers import OpenStackConnectionParams, wait_for_valid_connection
 from tests.integration.types import PrivateEndpointConfigs, ProxyConfig, SSHKey, TestConfigs
 
 logger = logging.getLogger(__name__)
@@ -486,10 +486,12 @@ async def ssh_connection_fixture(
     """The openstack server ssh connection fixture."""
     logger.info("Setting up SSH connection.")
     ssh_connection = wait_for_valid_connection(
-        connection=openstack_metadata.connection,
-        server_name=openstack_server.name,
-        network=openstack_metadata.network,
-        ssh_key=openstack_metadata.ssh_key.private_key,
+        connection_params=OpenStackConnectionParams(
+            connection=openstack_metadata.connection,
+            server_name=openstack_server.name,
+            network=openstack_metadata.network,
+            ssh_key=openstack_metadata.ssh_key.private_key,
+        ),
         proxy=proxy,
         dockerhub_mirror=dockerhub_mirror,
     )

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,0 +1,53 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Module for defining unit test fixtures."""
+
+import secrets
+from unittest.mock import MagicMock
+
+import pytest
+from ops.testing import Harness
+
+import image
+import state
+from charm import GithubRunnerImageBuilderCharm
+
+
+@pytest.fixture(name="harness")
+def harness_fixture():
+    """The ops testing harness fixture."""
+    harness = Harness(GithubRunnerImageBuilderCharm)
+    harness.begin()
+
+    # Replace config_changed handler temporarily.
+    config_changed_handler = harness.charm._on_config_changed
+    harness.charm._on_config_changed = MagicMock()
+    harness.update_config(
+        {
+            state.EXTERNAL_BUILD_CONFIG_NAME: True,
+            state.OPENSTACK_AUTH_URL_CONFIG_NAME: "https://test-auth-url.com/",
+            state.OPENSTACK_PASSWORD_CONFIG_NAME: secrets.token_hex(16),
+            state.OPENSTACK_PROJECT_DOMAIN_CONFIG_NAME: "test",
+            state.OPENSTACK_PROJECT_CONFIG_NAME: "test",
+            state.OPENSTACK_USER_DOMAIN_CONFIG_NAME: "test",
+            state.OPENSTACK_USER_CONFIG_NAME: "test",
+        }
+    )
+    harness.charm._on_config_changed = config_changed_handler
+
+    yield harness
+
+    harness.cleanup()
+
+
+@pytest.fixture(name="charm")
+def charm_fixture(harness: Harness) -> GithubRunnerImageBuilderCharm:
+    """The charm fixture from harness."""
+    return harness.charm
+
+
+@pytest.fixture(name="image_observer")
+def image_observer_fixture(charm: GithubRunnerImageBuilderCharm) -> image.Observer:
+    """The image observer from harness."""
+    return charm.image_observer

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -13,6 +13,9 @@ import image
 import state
 from charm import GithubRunnerImageBuilderCharm
 
+# Need access to protected functions for testing
+# pylint:disable=protected-access
+
 
 @pytest.fixture(name="harness")
 def harness_fixture():

--- a/tests/unit/factories.py
+++ b/tests/unit/factories.py
@@ -3,7 +3,6 @@
 
 """Factories for generating test data."""
 
-import secrets
 import typing
 from unittest.mock import MagicMock
 
@@ -80,15 +79,21 @@ class MockCharmFactory(factory.Factory):
 class CloudAuthFactory(factory.DictFactory):
     """Mock cloud auth dict object factory."""  # noqa: DCO060
 
-    auth_url = factory.Faker("url")
-    password = secrets.token_hex(16)
-    project_domain_name = factory.Faker("name")
-    project_name = factory.Faker("name")
-    user_domain_name = factory.Faker("name")
-    username = factory.Faker("name")
+    auth_url = "test-auth-url"
+    # We need to use known password for unit testing
+    password = "test-password"  # nosec: B105:hardcoded_password_string
+    project_domain_name = "test-project-domain"
+    project_name = "test-project-name"
+    user_domain_name = "test-user-domain"
+    username = "test-username"
 
 
-class CloudFactory(factory.DictFactory):
+class CloudFactory(factory.Factory):
     """Mock cloud dict object factory."""  # noqa: DCO060
+
+    class Meta:  # pylint: disable=too-few-public-methods
+        """Configuration for factory."""  # noqa: DCO060
+
+        model = MagicMock
 
     clouds = {"testcloud": CloudAuthFactory()}

--- a/tests/unit/test_builder.py
+++ b/tests/unit/test_builder.py
@@ -461,11 +461,7 @@ def test_get_latest_image_error(
     act: when get_latest_image is called.
     assert: GetLatestImageError is raised.
     """
-    monkeypatch.setattr(
-        subprocess,
-        "run",
-        error,
-    )
+    monkeypatch.setattr(subprocess, "run", MagicMock(side_effect=error))
 
     with pytest.raises(builder.GetLatestImageError):
         builder.get_latest_image(arch=MagicMock(), base=MagicMock(), cloud_name=MagicMock())
@@ -514,7 +510,7 @@ def test_upgrade_app_error(
     act: when upgrade_app is called.
     assert: UpgradeApplicationError is raised.
     """
-    monkeypatch.setattr(subprocess, "run", error)
+    monkeypatch.setattr(subprocess, "run", MagicMock(side_effect=error))
 
     with pytest.raises(builder.UpgradeApplicationError):
         builder.upgrade_app()

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -35,7 +35,7 @@ def patch_builder_init_config_from_charm(monkeypatch: pytest.MonkeyPatch):
                     base=MagicMock(),
                     cloud_config=state.OpenstackCloudsConfig(
                         clouds={
-                            "test": state._CloudsConfig(
+                            "test-builder": state._CloudsConfig(
                                 auth=state.CloudsAuthConfig(
                                     auth_url="test-url",
                                     password=secrets.token_hex(16),
@@ -65,9 +65,7 @@ def patch_builder_init_config_from_charm(monkeypatch: pytest.MonkeyPatch):
         pytest.param("_on_image_relation_changed", id="image_relation_changed"),
     ],
 )
-def test_block_on_image_relation_not_ready(
-    monkeypatch: pytest.MonkeyPatch, charm: GithubRunnerImageBuilderCharm, hook: str
-):
+def test_block_on_image_relation_not_ready(charm: GithubRunnerImageBuilderCharm, hook: str):
     """
     arrange: given hooks that should not run build when image relation is not yet ready.
     act: when the hook is called.

--- a/tests/unit/test_image.py
+++ b/tests/unit/test_image.py
@@ -25,6 +25,26 @@ def openstack_manager_fixture(monkeypatch: pytest.MonkeyPatch):
     return instance
 
 
+def test__on_image_relation_joined_unit_data_not_ready(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+):
+    """
+    arrange: given a monkeypatched OpenstackManager.get_latest_image_id that returns no image.
+    act: when _on_image_relation_joined hook is fired.
+    assert: image not ready warning is logged.
+    """
+    monkeypatch.setattr(state.BuilderRunConfig, "from_charm", MagicMock())
+    monkeypatch.setattr(
+        state.CloudsAuthConfig, "from_unit_relation_data", MagicMock(return_value=None)
+    )
+
+    observer = image.Observer(MagicMock())
+    observer._on_image_relation_joined(MagicMock())
+
+    assert all("Unit relation data not yet ready." in log for log in caplog.messages)
+
+
 def test__on_image_relation_joined_no_image(
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
@@ -62,17 +82,98 @@ def test__on_image_relation_joined(
     update_relation_data_mock.assert_called()
 
 
-def test_init(harness: Harness, image_observer: image.Observer):
+def test_update_image_data_no_unit_data(harness: Harness, image_observer: image.Observer):
     """
-    arrange: given a monkeypatched OpenstackManager.get_latest_image_id that returns an image ID.
+    arrange: given unit with no relation data populated yet.
+    act: when update_relation_data is called.
+    assert: the unit is skipped and no relation data update happens.
+    """
+    # ignore _on_image_relation_changed event handler
+    harness.charm._on_image_relation_changed = lambda *args, **kwargs: ...
+    relation_id = harness.add_relation(
+        state.IMAGE_RELATION,
+        remote_app="github-runner",
+    )
+    harness.add_relation_unit(relation_id=relation_id, remote_unit_name="github-runner/0")
+
+    image_observer.update_image_data(
+        cloud_image_ids=[builder.CloudImage(cloud_id="test_test", image_id="test")],
+        arch=state.Arch.ARM64,
+        base=state.BaseImage.JAMMY,
+    )
+
+    assert (
+        harness.get_relation_data(
+            relation_id=relation_id, app_or_unit=image_observer.model.unit.name
+        )
+        == {}
+    )
+
+
+def test_update_image_data(harness: Harness, image_observer: image.Observer):
+    """
+    arrange: given multiple relations.
     act: when _on_image_relation_joined hook is fired.
     assert: update_relation_data is called.
     """
+    # ignore _on_image_relation_changed event handler
     harness.charm._on_image_relation_changed = lambda *args, **kwargs: ...
-    harness.add_relation(
+    first_relation_id = harness.add_relation(
         state.IMAGE_RELATION,
         remote_app="github-runner",
-        unit_data={
+    )
+    harness.add_relation_unit(relation_id=first_relation_id, remote_unit_name="github-runner/0")
+    harness.update_relation_data(
+        relation_id=first_relation_id,
+        app_or_unit="github-runner/0",
+        key_values={
+            "auth_url": "test",
+            "password": "test",
+            "project_domain_name": "test",
+            "project_name": "test",
+            "user_domain_name": "test",
+            "username": "test",
+        },
+    )
+    harness.add_relation_unit(relation_id=first_relation_id, remote_unit_name="github-runner/1")
+    harness.update_relation_data(
+        relation_id=first_relation_id,
+        app_or_unit="github-runner/1",
+        key_values={
+            "auth_url": "test",
+            "password": "test",
+            "project_domain_name": "test",
+            "project_name": "test",
+            "user_domain_name": "test",
+            "username": "test",
+        },
+    )
+    second_relation_id = harness.add_relation(
+        state.IMAGE_RELATION,
+        remote_app="github-runner-two",
+    )
+    harness.add_relation_unit(
+        relation_id=second_relation_id, remote_unit_name="github-runner-two/0"
+    )
+    harness.update_relation_data(
+        relation_id=second_relation_id,
+        app_or_unit="github-runner-two/0",
+        key_values={
+            "auth_url": "test",
+            "password": "test",
+            "project_domain_name": "test",
+            "project_name": "test",
+            "user_domain_name": "test",
+            "username": "test",
+        },
+    )
+    harness.add_relation_unit(
+        relation_id=second_relation_id, remote_unit_name="github-runner-two/1"
+    )
+    harness.update_relation_data(
+        relation_id=second_relation_id,
+        app_or_unit="github-runner-two/1",
+        key_values={
             "auth_url": "test",
             "password": "test",
             "project_domain_name": "test",
@@ -83,7 +184,14 @@ def test_init(harness: Harness, image_observer: image.Observer):
     )
 
     image_observer.update_image_data(
-        cloud_image_ids=[builder.CloudImage(cloud_id="test", image_id="test")],
+        cloud_image_ids=[builder.CloudImage(cloud_id="test_test", image_id="test")],
         arch=state.Arch.ARM64,
         base=state.BaseImage.JAMMY,
     )
+
+    assert harness.get_relation_data(
+        relation_id=first_relation_id, app_or_unit=image_observer.model.unit.name
+    ) == {"id": "test", "tags": "arm64,jammy"}
+    assert harness.get_relation_data(
+        relation_id=second_relation_id, app_or_unit=image_observer.model.unit.name
+    ) == {"id": "test", "tags": "arm64,jammy"}

--- a/tests/unit/test_image.py
+++ b/tests/unit/test_image.py
@@ -9,7 +9,9 @@
 from unittest.mock import MagicMock
 
 import pytest
+from ops.testing import Harness
 
+import builder
 import image
 import state
 
@@ -33,6 +35,7 @@ def test__on_image_relation_joined_no_image(
     assert: image not ready warning is logged.
     """
     monkeypatch.setattr(state.BuilderRunConfig, "from_charm", MagicMock())
+    monkeypatch.setattr(state.CloudsAuthConfig, "from_unit_relation_data", MagicMock())
     monkeypatch.setattr(image.builder, "get_latest_image", MagicMock(return_value=""))
 
     observer = image.Observer(MagicMock())
@@ -41,36 +44,46 @@ def test__on_image_relation_joined_no_image(
     assert all("Image not yet ready." in log for log in caplog.messages)
 
 
-def test__on_image_relation_joined(monkeypatch: pytest.MonkeyPatch):
+def test__on_image_relation_joined(
+    monkeypatch: pytest.MonkeyPatch, image_observer: image.Observer
+):
     """
     arrange: given a monkeypatched OpenstackManager.get_latest_image_id that returns an image ID.
     act: when _on_image_relation_joined hook is fired.
     assert: update_relation_data is called.
     """
     monkeypatch.setattr(state.BuilderRunConfig, "from_charm", MagicMock())
+    monkeypatch.setattr(state.CloudsAuthConfig, "from_unit_relation_data", MagicMock())
     monkeypatch.setattr(image.builder, "get_latest_image", MagicMock(return_value="test-id"))
 
-    observer = image.Observer(MagicMock())
-    observer.update_image_data = (update_relation_data_mock := MagicMock())
-    observer._on_image_relation_joined(MagicMock())
+    image_observer.update_image_data = (update_relation_data_mock := MagicMock())
+    image_observer._on_image_relation_joined(MagicMock())
 
     update_relation_data_mock.assert_called()
 
 
-def test_update_relation_data(monkeypatch: pytest.MonkeyPatch):
+def test_init(harness: Harness, image_observer: image.Observer):
     """
     arrange: given a monkeypatched OpenstackManager.get_latest_image_id that returns an image ID.
     act: when _on_image_relation_joined hook is fired.
     assert: update_relation_data is called.
     """
-    monkeypatch.setattr(state.BuilderRunConfig, "from_charm", MagicMock())
-    observer = image.Observer(MagicMock())
-    observer.model.relations = {state.IMAGE_RELATION: [(relation := MagicMock())]}
-
-    observer.update_image_data(
-        image_id=(test_id := "test-image-id"), arch=state.Arch.ARM64, base=state.BaseImage.JAMMY
+    harness.charm._on_image_relation_changed = lambda *args, **kwargs: ...
+    harness.add_relation(
+        state.IMAGE_RELATION,
+        remote_app="github-runner",
+        unit_data={
+            "auth_url": "test",
+            "password": "test",
+            "project_domain_name": "test",
+            "project_name": "test",
+            "user_domain_name": "test",
+            "username": "test",
+        },
     )
 
-    relation.data[observer.model.unit].update.called_once_with(
-        image.ImageRelationData(id=test_id, arch=state.Arch.ARM64, base=state.BaseImage.JAMMY)
+    image_observer.update_image_data(
+        cloud_image_ids=[builder.CloudImage(cloud_id="test", image_id="test")],
+        arch=state.Arch.ARM64,
+        base=state.BaseImage.JAMMY,
     )

--- a/tests/unit/test_image.py
+++ b/tests/unit/test_image.py
@@ -57,11 +57,14 @@ def test__on_image_relation_joined_no_image(
     monkeypatch.setattr(state.BuilderRunConfig, "from_charm", MagicMock())
     monkeypatch.setattr(state.CloudsAuthConfig, "from_unit_relation_data", MagicMock())
     monkeypatch.setattr(image.builder, "get_latest_image", MagicMock(return_value=""))
+    mock_event = MagicMock()
+    mock_event.unit = MagicMock()
+    mock_event.unit.name = (test_unit_name := "test-unit-name")
 
     observer = image.Observer(MagicMock())
-    observer._on_image_relation_joined(MagicMock())
+    observer._on_image_relation_joined(mock_event)
 
-    assert all("Image not yet ready." in log for log in caplog.messages)
+    assert all(f"Image not yet ready for {test_unit_name}." in log for log in caplog.messages)
 
 
 def test__on_image_relation_joined(

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -263,8 +263,8 @@ def test_builder_run_config(monkeypatch: pytest.MonkeyPatch):
         run_config=state.BuilderRunConfig(
             arch=state.Arch.X64,
             base=state.BaseImage.JAMMY,
-            cloud_config={
-                "clouds": {
+            cloud_config=state.OpenstackCloudsConfig(
+                clouds={
                     state.CLOUD_NAME: {
                         "auth": {
                             "auth_url": "http://testing-auth/keystone",
@@ -276,7 +276,7 @@ def test_builder_run_config(monkeypatch: pytest.MonkeyPatch):
                         }
                     },
                 }
-            },
+            ),
             external_build_config=None,
             runner_version="1.234.5",
             num_revisions=5,
@@ -479,73 +479,30 @@ def test__parse_openstack_clouds_config_invalid(missing_config: str):
     assert "Please supply all OpenStack configurations." in str(exc)
 
 
-# mypy doesn't understand walrus operator here
-# pylint: disable=undefined-variable,unused-variable
-@pytest.mark.parametrize(
-    "openstack_config_from_relation, expected_config",
-    [
-        pytest.param(
-            None,
-            state.OpenstackCloudsConfig(
-                clouds={
-                    state.CLOUD_NAME: state._CloudsConfig(
-                        auth=state._CloudsAuthConfig(
-                            auth_url="http://testing-auth/keystone",
-                            # this is referring to hard-coded factory value since factory object
-                            # is not initialized and it is not a real secret
-                            password="testingvalue",  # nosec
-                            project_domain_name="project_domain_name",
-                            project_name="project_name",
-                            user_domain_name="user_domain_name",
-                            username="username",
-                        )
-                    ),
-                }
-            ),
-            id="None",
-        ),
-        pytest.param(
-            (relation_mock_config := MagicMock()),
-            state.OpenstackCloudsConfig(
-                clouds={
-                    state.CLOUD_NAME: state._CloudsConfig(
-                        auth=state._CloudsAuthConfig(
-                            auth_url="http://testing-auth/keystone",
-                            # this is referring to hard-coded factory value since factory object
-                            # is not initialized and it is not a real secret
-                            password="testingvalue",  # nosec
-                            project_domain_name="project_domain_name",
-                            project_name="project_name",
-                            user_domain_name="user_domain_name",
-                            username="username",
-                        )
-                    ),
-                    state.UPLOAD_CLOUD_NAME: state._CloudsConfig(auth=relation_mock_config.auth),
-                }
-            ),
-            id="mock data",
-        ),
-    ],
-)
-def test__parse_openstack_clouds_config(
-    monkeypatch: pytest.MonkeyPatch,
-    openstack_config_from_relation: state.GitHubRunnerOpenStackConfig | None,
-    expected_config: state.OpenstackCloudsConfig,
-):
+def test__parse_openstack_clouds_config():
     """
-    arrange: given openstack related config options and monkeypatched GitHubRunnerOpenStackConfig.
+    arrange: given mock charm from factory.
     act: when _parse_openstack_clouds_config is called.
     assert: expected clouds_config is returned.
     """
-    monkeypatch.setattr(
-        state.GitHubRunnerOpenStackConfig,
-        "from_charm",
-        MagicMock(return_value=openstack_config_from_relation),
-    )
     charm = MockCharmFactory()
 
     cloud_config = state._parse_openstack_clouds_config(charm=charm)
-    assert cloud_config == expected_config
+    assert cloud_config == state.OpenstackCloudsConfig(
+        clouds={
+            "builder": state._CloudsConfig(
+                auth=state.CloudsAuthConfig(
+                    auth_url="http://testing-auth/keystone",
+                    # We're using testing password value from the factory.
+                    password="testingvalue",  # nosec: B106:hardcoded_password_funcarg
+                    project_domain_name="project_domain_name",
+                    project_name="project_name",
+                    user_domain_name="user_domain_name",
+                    username="username",
+                )
+            )
+        }
+    )
 
 
 # pylint: enable=undefined-variable,unused-variable
@@ -612,66 +569,3 @@ def test_builder_init_config_invalid(
         state.BuilderInitConfig.from_charm(charm)
 
     assert expected_message in str(exc.getrepr())
-
-
-def test_github_runner_openstack_config_from_charm_no_relation_units():
-    """
-    arrange: given a github runner image relation with no relations.
-    act: when GitHubRunnerOpenStackConfig.from_charm is called.
-    assert: None is returned.
-    """
-    mock_charm = MagicMock()
-    mock_charm.model.relations = {state.IMAGE_RELATION: [(mock_relation := MagicMock())]}
-    mock_relation.units = None
-
-    assert state.GitHubRunnerOpenStackConfig.from_charm(charm=mock_charm) is None
-
-
-def test_github_runner_openstack_config_from_charm_no_unit_data():
-    """
-    arrange: given a github runner image relation with no relation data.
-    act: when GitHubRunnerOpenStackConfig.from_charm is called.
-    assert: None is returned.
-    """
-    mock_charm = MagicMock()
-    mock_charm.model.relations = {state.IMAGE_RELATION: [(relation_mock := MagicMock())]}
-    relation_mock.units = [(relation_unit_mock := MagicMock())]
-    relation_mock.data = {relation_unit_mock: None}
-
-    assert state.GitHubRunnerOpenStackConfig.from_charm(charm=mock_charm) is None
-
-
-def test_github_runner_openstack_config_from_charm():
-    """
-    arrange: given a github runner image relation.
-    act: when GitHubRunnerOpenStackConfig.from_charm is called.
-    assert: expected GitHubRunnerOpenStackConfig is returned.
-    """
-    mock_charm = MagicMock()
-    mock_charm.model.relations = {state.IMAGE_RELATION: [(relation_mock := MagicMock())]}
-    relation_mock.units = [(relation_unit_mock := MagicMock())]
-    relation_mock.data = {
-        relation_unit_mock: (
-            mock_data := {
-                "auth_url": "test",
-                "password": "test",
-                "project_domain_name": "test",
-                "project_name": "test",
-                "user_domain_name": "test",
-                "username": "test",
-            }
-        )
-    }
-
-    assert state.GitHubRunnerOpenStackConfig.from_charm(
-        charm=mock_charm
-    ) == state.GitHubRunnerOpenStackConfig(
-        auth=state._CloudsAuthConfig(
-            auth_url=mock_data["auth_url"],
-            password=mock_data["password"],
-            project_domain_name=mock_data["project_domain_name"],
-            project_name=mock_data["project_name"],
-            user_domain_name=mock_data["user_domain_name"],
-            username=mock_data["username"],
-        )
-    )

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -12,8 +12,10 @@ import typing
 from unittest.mock import MagicMock
 
 import pytest
+from ops.testing import Harness
 
 import state
+from charm import GithubRunnerImageBuilderCharm
 from tests.unit.factories import MockCharmFactory
 
 
@@ -506,6 +508,21 @@ def test__parse_openstack_clouds_config():
 
 
 # pylint: enable=undefined-variable,unused-variable
+
+
+def test__parse_openstack_clouds_auth_configs_from_relation_no_units(
+    harness: Harness, charm: GithubRunnerImageBuilderCharm, caplog: pytest.LogCaptureFixture
+):
+    """
+    arrange: given an image relation with no units.
+    act: when _parse_openstack_clouds_auth_configs_from_relation is called.
+    assert: warning log is printed.
+    """
+    harness.add_relation(state.IMAGE_RELATION, "github-runner")
+
+    state._parse_openstack_clouds_auth_configs_from_relation(charm=charm)
+
+    assert any("Units not yet joined" in log_line for log_line in caplog.messages)
 
 
 def test_builder_app_channel_from_charm_error():


### PR DESCRIPTION
Applicable spec: N/A

### Overview

- Build an image per relation and uploads once per cloud.

### Rationale

- This is to allow prevention of uploading the same image multiple times per relation to the same cloud which would exhaust the number of revisions kept and invalidate the images shared over the relation data for older relations.

### Juju Events Changes

- on image relation joined - fetches the latest image for the cloud provided by the event's unit

### Module Changes

- image.py - handle update relation to update the relation data for relation's cloud only.

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
