### PR TITLE
fix: install clouds_yaml on relation joined

### DIFF
--- a/src-docs/image.py.md
+++ b/src-docs/image.py.md
@@ -55,7 +55,7 @@ Shortcut for more simple access the model.
 
 ---
 
-<a href="../src/image.py#L80"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/image.py#L79"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `update_image_data`
 

--- a/src-docs/image.py.md
+++ b/src-docs/image.py.md
@@ -55,7 +55,7 @@ Shortcut for more simple access the model.
 
 ---
 
-<a href="../src/image.py#L79"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/image.py#L80"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `update_image_data`
 

--- a/src/image.py
+++ b/src/image.py
@@ -50,9 +50,8 @@ class Observer(ops.Object):
         Args:
             event: The event emitted when a relation is joined.
         """
-        init_config = state.BuilderInitConfig.from_charm(charm=self.charm)
-        builder.install_clouds_yaml(cloud_config=init_config.run_config.cloud_config)
-        if not init_config.run_config.upload_cloud_ids:
+        build_config = state.BuilderRunConfig.from_charm(charm=self.charm)
+        if not build_config.upload_cloud_ids:
             self.model.unit.status = ops.BlockedStatus(
                 f"{state.IMAGE_RELATION} integration required."
             )
@@ -64,8 +63,8 @@ class Observer(ops.Object):
             logger.warning("Unit relation data not yet ready.")
             return
         image_id = builder.get_latest_image(
-            arch=init_config.run_config.arch,
-            base=init_config.run_config.base,
+            arch=build_config.arch,
+            base=build_config.base,
             cloud_name=(cloud_id := unit_cloud_auth_config.get_id()),
         )
         if not image_id:
@@ -73,8 +72,8 @@ class Observer(ops.Object):
             return
         self.update_image_data(
             cloud_image_ids=[builder.CloudImage(cloud_id=cloud_id, image_id=image_id)],
-            arch=init_config.run_config.arch,
-            base=init_config.run_config.base,
+            arch=build_config.arch,
+            base=build_config.base,
         )
 
     def update_image_data(

--- a/src/image.py
+++ b/src/image.py
@@ -62,6 +62,7 @@ class Observer(ops.Object):
         if not unit_cloud_auth_config:
             logger.warning("Unit relation data not yet ready.")
             return
+        builder.install_clouds_yaml(build_config.cloud_config)
         image_id = builder.get_latest_image(
             arch=build_config.arch,
             base=build_config.base,

--- a/src/image.py
+++ b/src/image.py
@@ -50,8 +50,9 @@ class Observer(ops.Object):
         Args:
             event: The event emitted when a relation is joined.
         """
-        build_config = state.BuilderRunConfig.from_charm(charm=self.charm)
-        if not build_config.upload_cloud_ids:
+        init_config = state.BuilderInitConfig.from_charm(charm=self.charm)
+        builder.install_clouds_yaml(cloud_config=init_config.run_config.cloud_config)
+        if not init_config.run_config.upload_cloud_ids:
             self.model.unit.status = ops.BlockedStatus(
                 f"{state.IMAGE_RELATION} integration required."
             )
@@ -63,8 +64,8 @@ class Observer(ops.Object):
             logger.warning("Unit relation data not yet ready.")
             return
         image_id = builder.get_latest_image(
-            arch=build_config.arch,
-            base=build_config.base,
+            arch=init_config.run_config.arch,
+            base=init_config.run_config.base,
             cloud_name=(cloud_id := unit_cloud_auth_config.get_id()),
         )
         if not image_id:
@@ -72,8 +73,8 @@ class Observer(ops.Object):
             return
         self.update_image_data(
             cloud_image_ids=[builder.CloudImage(cloud_id=cloud_id, image_id=image_id)],
-            arch=build_config.arch,
-            base=build_config.base,
+            arch=init_config.run_config.arch,
+            base=init_config.run_config.base,
         )
 
     def update_image_data(

--- a/tests/unit/test_image.py
+++ b/tests/unit/test_image.py
@@ -56,6 +56,7 @@ def test__on_image_relation_joined_no_image(
     """
     monkeypatch.setattr(state.BuilderRunConfig, "from_charm", MagicMock())
     monkeypatch.setattr(state.CloudsAuthConfig, "from_unit_relation_data", MagicMock())
+    monkeypatch.setattr(builder, "install_clouds_yaml", MagicMock(return_value=""))
     monkeypatch.setattr(image.builder, "get_latest_image", MagicMock(return_value=""))
     mock_event = MagicMock()
     mock_event.unit = MagicMock()
@@ -77,7 +78,8 @@ def test__on_image_relation_joined(
     """
     monkeypatch.setattr(state.BuilderRunConfig, "from_charm", MagicMock())
     monkeypatch.setattr(state.CloudsAuthConfig, "from_unit_relation_data", MagicMock())
-    monkeypatch.setattr(image.builder, "get_latest_image", MagicMock(return_value="test-id"))
+    monkeypatch.setattr(builder, "install_clouds_yaml", MagicMock())
+    monkeypatch.setattr(builder, "get_latest_image", MagicMock(return_value="test-id"))
 
     image_observer.update_image_data = (update_relation_data_mock := MagicMock())
     image_observer._on_image_relation_joined(MagicMock())


### PR DESCRIPTION
Applicable spec: N/A

### Overview

- Installs/updates clouds.yaml content on image relation joined, before trying to fetch image from given cloud.

### Rationale

- Fixes bug where image fetch fails due to the clouds.yaml not containing the clouds.yaml configuration for the unit that has just joined the relation.

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
