### PR TITLE
fix: juju bug workaroud for module imports

### DIFF
--- a/src-docs/charm.py.md
+++ b/src-docs/charm.py.md
@@ -12,7 +12,7 @@ Entrypoint for GithubRunnerImageBuilder charm.
 ## <kbd>class</kbd> `GithubRunnerImageBuilderCharm`
 Charm GitHubRunner image builder application. 
 
-<a href="../src/charm.py#L30"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm.py#L37"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `__init__`
 
@@ -69,7 +69,7 @@ Unit that this execution is responsible for.
 
 ---
 
-<a href="../src/charm.py#L141"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm.py#L148"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `update_status`
 

--- a/src-docs/charm_utils.py.md
+++ b/src-docs/charm_utils.py.md
@@ -8,7 +8,7 @@ Module for functions containing charm utilities.
 
 ---
 
-<a href="../src/charm_utils.py#L34"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_utils.py#L36"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `block_if_invalid_config`
 
@@ -34,6 +34,19 @@ Create a decorator that puts the charm in blocked state if the config is wrong.
 
 ---
 
+<a href="../src/charm_utils.py#L84"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+## <kbd>function</kbd> `remove_residual_venv_dirs`
+
+```python
+remove_residual_venv_dirs() → None
+```
+
+Remove the residual empty directories from last revision if it exists. 
+
+
+---
+
 ## <kbd>class</kbd> `GithubRunnerImageBuilderCharmProtocol`
 Protocol to use for the decorator to block if invalid. 
 
@@ -42,7 +55,7 @@ Protocol to use for the decorator to block if invalid.
 
 ---
 
-<a href="../src/charm_utils.py#L22"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_utils.py#L24"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `update_status`
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -5,6 +5,13 @@
 
 """Entrypoint for GithubRunnerImageBuilder charm."""
 
+from charm_utils import remove_residual_venv_dirs
+
+# This is a workaround for https://bugs.launchpad.net/juju/+bug/2058335
+# It is important that this is run before importing any other modules.
+# pylint: disable=wrong-import-position,wrong-import-order
+remove_residual_venv_dirs()
+
 import logging
 import typing
 

--- a/tox.ini
+++ b/tox.ini
@@ -66,7 +66,9 @@ commands =
       --skip {toxinidir}/build --skip {toxinidir}/lib --skip {toxinidir}/venv \
       --skip {toxinidir}/.mypy_cache --skip {toxinidir}/icon.svg
     # pflake8 wrapper supports config from pyproject.toml
-    pflake8 {[vars]all_path} --ignore=W503
+    # ignore E402 (Module level import not at top of file) due to Juju bug.
+    # See: https://bugs.launchpad.net/juju/+bug/2058335
+    pflake8 {[vars]all_path} --ignore=W503,E402
     isort --check-only --diff {[vars]all_path}
     black --check --diff {[vars]all_path}
     mypy {[vars]all_path}


### PR DESCRIPTION
Applicable spec: N/A

### Overview

- Workaround for juju bug where empty package directories cause import error

### Rationale

- The charm crashes on charm upgrade.

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
