### PR TITLE
feat: script url config

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -169,6 +169,13 @@ config:
       description: |
         The GitHub runner version to use, e.g. 2.317.0. Empty default value will fetch the latest
         version by default. See https://github.com/actions/runner/releases.
+    script-url:
+      type: string
+      default: ""
+      description: |
+        URL to external script to run during cloud-init. Allows user-defined customization scripts
+        to be run. This script is run as root, within the cloud-init user-data script.
+
 
 provides:
   image:

--- a/src-docs/builder.py.md
+++ b/src-docs/builder.py.md
@@ -111,7 +111,7 @@ Run a build immediately.
 
 ---
 
-<a href="../src/builder.py#L466"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/builder.py#L471"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `get_latest_images`
 
@@ -142,7 +142,7 @@ Fetch the latest image build ID.
 
 ---
 
-<a href="../src/builder.py#L601"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/builder.py#L606"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `upgrade_app`
 

--- a/src-docs/state.py.md
+++ b/src-docs/state.py.md
@@ -29,6 +29,7 @@ Module for interacting with charm state and configurations.
 - **OPENSTACK_USER_CONFIG_NAME**
 - **REVISION_HISTORY_LIMIT_CONFIG_NAME**
 - **RUNNER_VERSION_CONFIG_NAME**
+- **SCRIPT_URL_CONFIG_NAME**
 - **IMAGE_RELATION**
 
 
@@ -69,7 +70,7 @@ The ubuntu OS base image to build and deploy runners on.
 ## <kbd>class</kbd> `BuildConfigInvalidError`
 Raised when charm config related to image build config is invalid. 
 
-<a href="../src/state.py#L55"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/state.py#L56"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `__init__`
 
@@ -94,7 +95,7 @@ Initialize a new instance of the CharmConfigInvalidError exception.
 ## <kbd>class</kbd> `BuildIntervalConfigError`
 Represents an error with invalid interval configuration. 
 
-<a href="../src/state.py#L55"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/state.py#L56"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `__init__`
 
@@ -137,7 +138,7 @@ This is managed by the application's git tag and versioning tag in pyproject.tom
 ## <kbd>class</kbd> `BuilderAppChannelInvalidError`
 Represents invalid builder app channel configuration. 
 
-<a href="../src/state.py#L55"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/state.py#L56"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `__init__`
 
@@ -178,7 +179,7 @@ The image builder setup config.
 
 ---
 
-<a href="../src/state.py#L853"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/state.py#L883"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `from_charm`
 
@@ -219,7 +220,7 @@ Configurations for running builder periodically.
 
 ---
 
-<a href="../src/state.py#L516"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/state.py#L521"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `from_charm`
 
@@ -246,7 +247,7 @@ Initialize build state from current charm instance.
 ## <kbd>class</kbd> `BuilderSetupConfigInvalidError`
 Raised when charm config related to image build setup config is invalid. 
 
-<a href="../src/state.py#L55"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/state.py#L56"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `__init__`
 
@@ -277,7 +278,7 @@ Raised when charm config is invalid.
  
  - <b>`msg`</b>:  Explanation of the error. 
 
-<a href="../src/state.py#L55"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/state.py#L56"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `__init__`
 
@@ -329,7 +330,7 @@ The cloud name from cloud_config.
 
 ---
 
-<a href="../src/state.py#L422"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/state.py#L427"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `from_charm`
 
@@ -394,7 +395,7 @@ Returns the set of fields that have been explicitly set on this model instance.
 
 ---
 
-<a href="../src/state.py#L288"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/state.py#L289"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `from_unit_relation_data`
 
@@ -417,7 +418,7 @@ Get auth data from unit relation data.
 
 ---
 
-<a href="../src/state.py#L280"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/state.py#L281"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `get_id`
 
@@ -450,7 +451,7 @@ Configurations for external builder VMs.
 
 ---
 
-<a href="../src/state.py#L228"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/state.py#L229"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `from_charm`
 
@@ -487,13 +488,14 @@ Image configuration parameters.
  - <b>`microk8s_channels`</b>:  The Microk8s channels to install on the images. 
  - <b>`prefix`</b>:  The image name prefix (application name). 
  - <b>`runner_version`</b>:  The GitHub runner version to embed in the image. Latest version if empty. 
+ - <b>`script_url`</b>:  The external script to run during cloud-init process. 
 
 
 
 
 ---
 
-<a href="../src/state.py#L365"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/state.py#L368"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `from_charm`
 
@@ -520,7 +522,7 @@ Initialize image config state from current charm instance.
 ## <kbd>class</kbd> `InsufficientCoresError`
 Represents an error with invalid charm resource configuration. 
 
-<a href="../src/state.py#L55"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/state.py#L56"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `__init__`
 
@@ -545,7 +547,7 @@ Initialize a new instance of the CharmConfigInvalidError exception.
 ## <kbd>class</kbd> `InvalidBaseImageError`
 Represents an error with invalid charm base image configuration. 
 
-<a href="../src/state.py#L55"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/state.py#L56"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `__init__`
 
@@ -570,7 +572,7 @@ Initialize a new instance of the CharmConfigInvalidError exception.
 ## <kbd>class</kbd> `InvalidCloudConfigError`
 Represents an error with openstack cloud config. 
 
-<a href="../src/state.py#L55"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/state.py#L56"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `__init__`
 
@@ -595,7 +597,7 @@ Initialize a new instance of the CharmConfigInvalidError exception.
 ## <kbd>class</kbd> `InvalidDockerHubCacheURLError`
 Represents an error with DockerHub cache URL. 
 
-<a href="../src/state.py#L55"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/state.py#L56"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `__init__`
 
@@ -620,7 +622,32 @@ Initialize a new instance of the CharmConfigInvalidError exception.
 ## <kbd>class</kbd> `InvalidRevisionHistoryLimitError`
 Represents an error with invalid revision history limit configuration value. 
 
-<a href="../src/state.py#L55"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/state.py#L56"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+### <kbd>function</kbd> `__init__`
+
+```python
+__init__(msg: str | None = None)
+```
+
+Initialize a new instance of the CharmConfigInvalidError exception. 
+
+
+
+**Args:**
+ 
+ - <b>`msg`</b>:  Explanation of the error. 
+
+
+
+
+
+---
+
+## <kbd>class</kbd> `InvalidScriptURLError`
+Represents script URL configuration. 
+
+<a href="../src/state.py#L56"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `__init__`
 
@@ -645,7 +672,7 @@ Initialize a new instance of the CharmConfigInvalidError exception.
 ## <kbd>class</kbd> `JujuChannelInvalidError`
 Represents invalid Juju channels configuration. 
 
-<a href="../src/state.py#L55"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/state.py#L56"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `__init__`
 
@@ -670,7 +697,7 @@ Initialize a new instance of the CharmConfigInvalidError exception.
 ## <kbd>class</kbd> `Microk8sChannelInvalidError`
 Represents invalid Microk8s channels configuration. 
 
-<a href="../src/state.py#L55"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/state.py#L56"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `__init__`
 
@@ -745,7 +772,7 @@ Proxy configuration.
 
 ---
 
-<a href="../src/state.py#L199"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/state.py#L200"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `from_env`
 
@@ -778,7 +805,7 @@ External service configuration values.
 
 ---
 
-<a href="../src/state.py#L460"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/state.py#L465"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `from_charm`
 
@@ -805,7 +832,7 @@ Initialize the external service configurations from charm.
 ## <kbd>class</kbd> `UnsupportedArchitectureError`
 Raised when given machine charm architecture is unsupported. 
 
-<a href="../src/state.py#L55"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/state.py#L56"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `__init__`
 

--- a/src/builder.py
+++ b/src/builder.py
@@ -246,8 +246,9 @@ class _RunImageConfig:
         base: The Ubuntu base OS image to build the image on.
         juju: The Juju channel to install and bootstrap on the image.
         microk8s: The Microk8s channel to install and bootstrap on the image.
-        runner_version: The GitHub runner version to pin, defaults to latest.
         prefix: The image prefix.
+        runner_version: The GitHub runner version to pin, defaults to latest.
+        script_url: The external script to run during cloud-init process.
         image_name: The image name derived from image configuration attributes.
     """
 
@@ -255,8 +256,9 @@ class _RunImageConfig:
     base: state.BaseImage
     juju: str
     microk8s: str
-    runner_version: str | None
     prefix: str
+    script_url: str | None
+    runner_version: str | None
 
     @property
     def image_name(self) -> str:
@@ -342,8 +344,9 @@ def _parametrize_build(config: state.BuilderRunConfig) -> tuple[RunConfig, ...]:
                             base=base,
                             juju=juju,
                             microk8s=microk8s,
-                            runner_version=config.image_config.runner_version,
                             prefix=config.image_config.prefix,
+                            runner_version=config.image_config.runner_version,
+                            script_url=config.image_config.script_url,
                         ),
                         cloud=_RunCloudConfig(
                             build_cloud=config.cloud_config.cloud_name,
@@ -404,6 +407,8 @@ def _run(config: RunConfig) -> list[CloudImage]:
             commands.extend(["--microk8s", config.image.microk8s])
         if config.external_service.dockerhub_cache:
             commands.extend(["--dockerhub-cache", config.external_service.dockerhub_cache])
+        if config.image.script_url:
+            commands.extend(["--script-url", config.image.script_url])
         commands.extend(
             [
                 "--experimental-external",

--- a/tests/unit/factories.py
+++ b/tests/unit/factories.py
@@ -26,6 +26,7 @@ from state import (
     OPENSTACK_USER_DOMAIN_CONFIG_NAME,
     REVISION_HISTORY_LIMIT_CONFIG_NAME,
     RUNNER_VERSION_CONFIG_NAME,
+    SCRIPT_URL_CONFIG_NAME,
     ExternalBuildConfig,
     OpenstackCloudsConfig,
     _CloudsConfig,
@@ -98,6 +99,7 @@ class MockCharmFactory(factory.Factory):
             OPENSTACK_USER_CONFIG_NAME: "test-username",
             REVISION_HISTORY_LIMIT_CONFIG_NAME: "5",
             RUNNER_VERSION_CONFIG_NAME: "1.234.5",
+            SCRIPT_URL_CONFIG_NAME: "",
         }
     )
 

--- a/tests/unit/test_builder.py
+++ b/tests/unit/test_builder.py
@@ -435,6 +435,7 @@ def test_run(monkeypatch: pytest.MonkeyPatch):
                     microk8s_channels=("",),
                     prefix="",
                     runner_version="",
+                    script_url=None,
                 ),
                 service_config=state.ServiceConfig(
                     dockerhub_cache="https://dockerhub-cache.internal:5000", proxy=None
@@ -450,6 +451,7 @@ def test_run(monkeypatch: pytest.MonkeyPatch):
                         microk8s="",
                         runner_version="",
                         prefix="",
+                        script_url=None,
                     ),
                     cloud=builder._RunCloudConfig(
                         build_cloud="builder",
@@ -471,6 +473,7 @@ def test_run(monkeypatch: pytest.MonkeyPatch):
                         microk8s="",
                         runner_version="",
                         prefix="",
+                        script_url=None,
                     ),
                     cloud=builder._RunCloudConfig(
                         build_cloud="builder",
@@ -492,6 +495,7 @@ def test_run(monkeypatch: pytest.MonkeyPatch):
                         microk8s="",
                         runner_version="",
                         prefix="",
+                        script_url=None,
                     ),
                     cloud=builder._RunCloudConfig(
                         build_cloud="builder",
@@ -513,6 +517,7 @@ def test_run(monkeypatch: pytest.MonkeyPatch):
                         microk8s="",
                         runner_version="",
                         prefix="",
+                        script_url=None,
                     ),
                     cloud=builder._RunCloudConfig(
                         build_cloud="builder",
@@ -591,6 +596,7 @@ def test__run_error(
                     juju="3.1/stable",
                     microk8s="",
                     prefix="app-name",
+                    script_url=None,
                 ),
                 cloud=builder._RunCloudConfig(
                     build_cloud="test",
@@ -613,6 +619,7 @@ def test__run_error(
                     juju="3.1/stable",
                     microk8s="",
                     prefix="app-name",
+                    script_url=None,
                 ),
                 cloud=builder._RunCloudConfig(
                     build_cloud="test",
@@ -638,6 +645,7 @@ def test__run_error(
                     juju="",
                     microk8s="",
                     prefix="app-name",
+                    script_url=None,
                 ),
                 cloud=builder._RunCloudConfig(
                     build_cloud="test",
@@ -684,6 +692,7 @@ def test__run(monkeypatch: pytest.MonkeyPatch, run_config: builder.RunConfig):
                 microk8s="",
                 runner_version="",
                 prefix="app-name",
+                script_url=None,
             ),
             "app-name-jammy-arm64",
             id="raw",
@@ -696,6 +705,7 @@ def test__run(monkeypatch: pytest.MonkeyPatch, run_config: builder.RunConfig):
                 microk8s="",
                 runner_version="",
                 prefix="app-name",
+                script_url=None,
             ),
             "app-name-jammy-arm64-juju-3.1-stable",
             id="juju",
@@ -708,6 +718,7 @@ def test__run(monkeypatch: pytest.MonkeyPatch, run_config: builder.RunConfig):
                 microk8s="1.29-strict/stable",
                 runner_version="",
                 prefix="app-name",
+                script_url=None,
             ),
             "app-name-jammy-arm64-mk8s-1.29-strict-stable",
             id="microk8s",
@@ -797,6 +808,7 @@ def test__fetch_config_image_name(config: builder.FetchConfig, expected_name: st
                     microk8s_channels=("",),
                     prefix="",
                     runner_version="",
+                    script_url=None,
                 ),
                 cloud_config=state.CloudConfig(
                     openstack_clouds_config=factories.OpenstackCloudsConfigFactory(),

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -44,6 +44,7 @@ def patch_builder_init_config_from_charm(monkeypatch: pytest.MonkeyPatch):
                         microk8s_channels=("1.29-strict/stable",),
                         prefix="app-name",
                         runner_version="",
+                        script_url=None,
                     ),
                     service_config=state.ServiceConfig(
                         dockerhub_cache="https://dockerhub-cache.internal:5000", proxy=None
@@ -163,6 +164,7 @@ def test__on_config_changed(
                         microk8s_channels=("",),
                         prefix="",
                         runner_version="",
+                        script_url=None,
                     ),
                     cloud_config=state.CloudConfig(
                         openstack_clouds_config=factories.OpenstackCloudsConfigFactory(
@@ -265,6 +267,7 @@ def test__on_run(monkeypatch: pytest.MonkeyPatch, charm: GithubRunnerImageBuilde
                     microk8s_channels=("",),
                     prefix="",
                     runner_version="",
+                    script_url=None,
                 ),
                 cloud_config=state.CloudConfig(
                     openstack_clouds_config=factories.OpenstackCloudsConfigFactory(clouds={}),
@@ -288,6 +291,7 @@ def test__on_run(monkeypatch: pytest.MonkeyPatch, charm: GithubRunnerImageBuilde
                     microk8s_channels=("",),
                     prefix="",
                     runner_version="",
+                    script_url=None,
                 ),
                 cloud_config=state.CloudConfig(
                     openstack_clouds_config=factories.OpenstackCloudsConfigFactory(


### PR DESCRIPTION
Applicable spec: <link>

### Overview

- Exposes configuration option to embed external script to be run at the end of user defined cloud-init script.

### Rationale

- Allows customisation of images via publicly available script.

### Juju Events Changes

- Added config option `script-url`.

### Module Changes

- `state.py` now processes `script-url` configuration option.
- `builder.py` now parametrizes images with script-url option and passes the `script-url` flag to the cli.

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
