### PR TITLE
fix: cron newline

### DIFF
--- a/src/builder.py
+++ b/src/builder.py
@@ -169,7 +169,7 @@ def configure_cron(unit_name: str, interval: int) -> bool:
     ]
 
     builder_exec_command: str = " ".join(commands)
-    cron_text = f"0 */{interval} * * * {UBUNTU_USER} {builder_exec_command}"
+    cron_text = f"0 */{interval} * * * {UBUNTU_USER} {builder_exec_command}\n"
 
     if not _should_configure_cron(cron_contents=cron_text):
         return False

--- a/tests/unit/test_builder.py
+++ b/tests/unit/test_builder.py
@@ -320,7 +320,7 @@ def test_configure_cron_no_reconfigure(monkeypatch: pytest.MonkeyPatch):
     [
         pytest.param(
             """0 */1 * * * ubuntu /usr/bin/run-one /usr/bin/bash -c \
-/usr/bin/juju-exec "test-unit-name" "JUJU_DISPATCH_PATH=run HOME=/home/ubuntu ./dispatch"\
+/usr/bin/juju-exec "test-unit-name" "JUJU_DISPATCH_PATH=run HOME=/home/ubuntu ./dispatch"
 """,
             id="runner version set",
         ),


### PR DESCRIPTION
Applicable spec: N/A

### Overview

Fixes current cron retrigger build image which was not getting triggered due to missing EOF newline.

### Rationale

Fixes bug w/ CRON build.

### Juju Events Changes

None.

### Module Changes

None.

### Library Changes

None.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
