### PR TITLE
chore: use passwords from env vars in integration tests

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @canonical/is-charms
+*       @cbartz @yhaliaw @javierdelapuente

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,11 @@ tox run -e integration   # integration tests
 tox                      # runs 'format', 'lint', and 'unit' environments
 ```
 
+
+The integration tests require options to be passed via the commandline (see `tests/conftest.py`) and 
+environment variables `OPENSTACK_PASSWORD_AMD64` and `OPENSTACK_PASSWORD_ARM64` to be able 
+to deploy the charm and/or upload images to OpenStack.
+
 ## Build the charm
 
 Build the charm in this git repository using:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,11 +40,6 @@ def pytest_addoption(parser: Parser):
         help="The URL to Openstack authentication service, i.e. keystone.",
     )
     parser.addoption(
-        "--openstack-password-arm64",
-        action="store",
-        help="The password to authenticate to Openstack service.",
-    )
-    parser.addoption(
         "--openstack-project-domain-name-arm64",
         action="store",
         help="The Openstack project domain name to use.",
@@ -84,11 +79,6 @@ def pytest_addoption(parser: Parser):
         "--openstack-auth-url-amd64",
         action="store",
         help="The URL to Openstack authentication service, i.e. keystone.",
-    )
-    parser.addoption(
-        "--openstack-password-amd64",
-        action="store",
-        help="The password to authenticate to Openstack service.",
     )
     parser.addoption(
         "--openstack-project-domain-name-amd64",

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -209,8 +209,7 @@ def private_endpoint_configs_fixture(
     """The OpenStack private endpoint configurations."""
     if arch == "arm64":
         auth_url = pytestconfig.getoption("--openstack-auth-url-arm64")
-        password = os.getenv("OPENSTACK_PASSWORD_ARM64")
-        assert password is not None, "please specify OPENSTACK_PASSWORD_ARM64 environment var"
+        password = os.getenv("OPENSTACK_PASSWORD_ARM64", "")
         project_domain_name = pytestconfig.getoption("--openstack-project-domain-name-arm64")
         project_name = pytestconfig.getoption("--openstack-project-name-arm64")
         user_domain_name = pytestconfig.getoption("--openstack-user-domain-name-arm64")
@@ -218,8 +217,7 @@ def private_endpoint_configs_fixture(
         region_name = pytestconfig.getoption("--openstack-region-name-arm64")
     else:
         auth_url = pytestconfig.getoption("--openstack-auth-url-amd64")
-        password = os.getenv("OPENSTACK_PASSWORD_AMD64")
-        assert password is not None, "please specify OPENSTACK_PASSWORD_AMD64 environment var"
+        password = os.getenv("OPENSTACK_PASSWORD_AMD64", "")
         project_domain_name = pytestconfig.getoption("--openstack-project-domain-name-amd64")
         project_name = pytestconfig.getoption("--openstack-project-name-amd64")
         user_domain_name = pytestconfig.getoption("--openstack-user-domain-name-amd64")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -178,7 +178,6 @@ async def test_charm_fixture(
     logger.info("Test charm removed.")
 
 
-
 @pytest.fixture(scope="module", name="network_name")
 def network_name_fixture(pytestconfig: pytest.Config, arch: Literal["amd64", "arm64"]) -> str:
     """Network to use to spawn test instances under."""
@@ -211,6 +210,7 @@ def private_endpoint_configs_fixture(
     if arch == "arm64":
         auth_url = pytestconfig.getoption("--openstack-auth-url-arm64")
         password = os.getenv("OPENSTACK_PASSWORD_ARM64")
+        assert password is not None, "please specify OPENSTACK_PASSWORD_ARM64 environment var"
         project_domain_name = pytestconfig.getoption("--openstack-project-domain-name-arm64")
         project_name = pytestconfig.getoption("--openstack-project-name-arm64")
         user_domain_name = pytestconfig.getoption("--openstack-user-domain-name-arm64")
@@ -219,6 +219,7 @@ def private_endpoint_configs_fixture(
     else:
         auth_url = pytestconfig.getoption("--openstack-auth-url-amd64")
         password = os.getenv("OPENSTACK_PASSWORD_AMD64")
+        assert password is not None, "please specify OPENSTACK_PASSWORD_AMD64 environment var"
         project_domain_name = pytestconfig.getoption("--openstack-project-domain-name-amd64")
         project_name = pytestconfig.getoption("--openstack-project-name-amd64")
         user_domain_name = pytestconfig.getoption("--openstack-user-domain-name-amd64")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -5,6 +5,7 @@
 import functools
 import logging
 import multiprocessing
+import os
 import platform
 import secrets
 import string
@@ -177,12 +178,6 @@ async def test_charm_fixture(
     logger.info("Test charm removed.")
 
 
-@pytest.fixture(scope="module", name="openstack_clouds_yaml")
-def openstack_clouds_yaml_fixture(pytestconfig: pytest.Config) -> str:
-    """Configured clouds-yaml setting."""
-    clouds_yaml = pytestconfig.getoption("--openstack-clouds-yaml")
-    return clouds_yaml
-
 
 @pytest.fixture(scope="module", name="network_name")
 def network_name_fixture(pytestconfig: pytest.Config, arch: Literal["amd64", "arm64"]) -> str:
@@ -215,7 +210,7 @@ def private_endpoint_configs_fixture(
     """The OpenStack private endpoint configurations."""
     if arch == "arm64":
         auth_url = pytestconfig.getoption("--openstack-auth-url-arm64")
-        password = pytestconfig.getoption("--openstack-password-arm64")
+        password = os.getenv("OPENSTACK_PASSWORD_ARM64")
         project_domain_name = pytestconfig.getoption("--openstack-project-domain-name-arm64")
         project_name = pytestconfig.getoption("--openstack-project-name-arm64")
         user_domain_name = pytestconfig.getoption("--openstack-user-domain-name-arm64")
@@ -223,7 +218,7 @@ def private_endpoint_configs_fixture(
         region_name = pytestconfig.getoption("--openstack-region-name-arm64")
     else:
         auth_url = pytestconfig.getoption("--openstack-auth-url-amd64")
-        password = pytestconfig.getoption("--openstack-password-amd64")
+        password = os.getenv("OPENSTACK_PASSWORD_AMD64")
         project_domain_name = pytestconfig.getoption("--openstack-project-domain-name-amd64")
         project_name = pytestconfig.getoption("--openstack-project-name-amd64")
         user_domain_name = pytestconfig.getoption("--openstack-user-domain-name-amd64")
@@ -254,8 +249,8 @@ def private_endpoint_configs_fixture(
     }
 
 
-@pytest.fixture(scope="module", name="private_endpoint_clouds_yaml")
-def private_endpoint_clouds_yaml_fixture(
+@pytest.fixture(scope="module", name="clouds_yaml_contents")
+def clouds_yaml_fixture(
     private_endpoint_configs: PrivateEndpointConfigs,
 ) -> Optional[str]:
     """The openstack private endpoint clouds yaml."""
@@ -272,21 +267,6 @@ def private_endpoint_clouds_yaml_fixture(
             "region_name": private_endpoint_configs["region_name"],
         }
     )
-
-
-@pytest.fixture(scope="module", name="clouds_yaml_contents")
-def clouds_yaml_contents_fixture(
-    openstack_clouds_yaml: Optional[str], private_endpoint_clouds_yaml: Optional[str]
-):
-    """The Openstack clouds yaml or private endpoint cloud yaml contents."""
-    clouds_yaml_contents = openstack_clouds_yaml or private_endpoint_clouds_yaml
-    assert clouds_yaml_contents, (
-        "Please specify --openstack-clouds-yaml or all of private endpoint arguments "
-        "(--openstack-auth-url, --openstack-password, --openstack-project-domain-name, "
-        "--openstack-project-name, --openstack-user-domain-name, --openstack-user-name, "
-        "--openstack-region-name)"
-    )
-    return clouds_yaml_contents
 
 
 @pytest.fixture(scope="module", name="openstack_connection")

--- a/tox.ini
+++ b/tox.ini
@@ -146,6 +146,8 @@ commands =
 description = Run integration tests
 pass_env =
     PYTEST_ADDOPTS
+    OPENSTACK_PASSWORD_AMD64
+    OPENSTACK_PASSWORD_ARM64
 deps =
     juju
     pytest


### PR DESCRIPTION
Applicable spec: <link>

### Overview

1. Use passwords from env vars in integration tests.
2. update codeowners

### Rationale

1. To avoid leaking secrets.
2. To get automatic reviews from the right people (according to the roadmap planning).


### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
