### PR TITLE
Fix local building

### DIFF
--- a/src/builder.py
+++ b/src/builder.py
@@ -338,8 +338,8 @@ class CloudConfig:
     """
 
     build_cloud: str
-    build_flavor: str
-    build_network: str
+    build_flavor: str | None
+    build_network: str | None
     resource_prefix: str
     num_revisions: int
     upload_clouds: typing.Iterable[str]

--- a/src/charm.py
+++ b/src/charm.py
@@ -189,8 +189,16 @@ class GithubRunnerImageBuilderCharm(ops.CharmBase):
         return builder.StaticConfigs(
             cloud_config=builder.CloudConfig(
                 build_cloud=builder_config.cloud_config.cloud_name,
-                build_flavor=builder_config.cloud_config.external_build_config.flavor,
-                build_network=builder_config.cloud_config.external_build_config.network,
+                build_flavor=(
+                    builder_config.cloud_config.external_build_config.flavor
+                    if builder_config.cloud_config.external_build_config
+                    else None
+                ),
+                build_network=(
+                    builder_config.cloud_config.external_build_config.network
+                    if builder_config.cloud_config.external_build_config
+                    else None
+                ),
                 resource_prefix=builder_config.app_config.resource_prefix,
                 num_revisions=builder_config.cloud_config.num_revisions,
                 upload_clouds=builder_config.cloud_config.upload_cloud_ids,

--- a/tests/unit/requirements.txt
+++ b/tests/unit/requirements.txt
@@ -1,1 +1,1 @@
-factory-boy>=3,<4
+factory-boy ==3.3.1


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->

For the github-runner charm, we use the locat (`experimental-external-build=false`) building of charms. Until now the revision "2" was pinned. When trying to update it to a more recent one, it fails. The charm does not work with local building.

### Rationale

<!-- The reason the change is needed -->

```
unit-github-runner-image-builder-0: 14:43:21 ERROR unit.github-runner-image-builder/0.juju-log image:0: Uncaught exception while in charm code:
Traceback (most recent call last):
  File "/var/lib/juju/agents/unit-github-runner-image-builder-0/charm/./src/charm.py", line 224, in <module>
    ops.main.main(GithubRunnerImageBuilderCharm)
  File "/var/lib/juju/agents/unit-github-runner-image-builder-0/charm/venv/ops/__init__.py", line 348, in main
    return _legacy_main.main(
  File "/var/lib/juju/agents/unit-github-runner-image-builder-0/charm/venv/ops/main.py", line 45, in main
    return _main.main(charm_class=charm_class, use_juju_for_storage=use_juju_for_storage)
  File "/var/lib/juju/agents/unit-github-runner-image-builder-0/charm/venv/ops/_main.py", line 543, in main
    manager.run()
  File "/var/lib/juju/agents/unit-github-runner-image-builder-0/charm/venv/ops/_main.py", line 529, in run
    self._emit()
  File "/var/lib/juju/agents/unit-github-runner-image-builder-0/charm/venv/ops/_main.py", line 518, in _emit
    _emit_charm_event(self.charm, self.dispatcher.event_name, self._juju_context)
  File "/var/lib/juju/agents/unit-github-runner-image-builder-0/charm/venv/ops/_main.py", line 134, in _emit_charm_event
    event_to_emit.emit(*args, **kwargs)
  File "/var/lib/juju/agents/unit-github-runner-image-builder-0/charm/venv/ops/framework.py", line 347, in emit
    framework._emit(event)
  File "/var/lib/juju/agents/unit-github-runner-image-builder-0/charm/venv/ops/framework.py", line 857, in _emit
    self._reemit(event_path)
  File "/var/lib/juju/agents/unit-github-runner-image-builder-0/charm/venv/ops/framework.py", line 947, in _reemit
    custom_handler(event)
  File "/var/lib/juju/agents/unit-github-runner-image-builder-0/charm/src/charm_utils.py", line 68, in wrapper
    return method(instance, event)
  File "/var/lib/juju/agents/unit-github-runner-image-builder-0/charm/./src/charm.py", line 102, in _on_image_relation_changed
    self._run()
  File "/var/lib/juju/agents/unit-github-runner-image-builder-0/charm/./src/charm.py", line 158, in _run
    static_config=self._get_static_config(builder_config=builder_config),
  File "/var/lib/juju/agents/unit-github-runner-image-builder-0/charm/./src/charm.py", line 192, in _get_static_config
    build_flavor=builder_config.cloud_config.external_build_config.flavor,
AttributeError: 'NoneType' object has no attribute 'flavor'
```

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [ ] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation is generated using `src-docs`
- [ ] The documentation for charmhub is updated.
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
