### PR TITLE
feat: s390x images

### DIFF
--- a/app/src/github_runner_image_builder/config.py
+++ b/app/src/github_runner_image_builder/config.py
@@ -22,6 +22,7 @@ class Arch(str, Enum):
 
     ARM64 = "arm64"
     X64 = "x64"
+    S390X = "s390x"
 
     def to_openstack(self) -> str:
         """Convert the architecture to OpenStack compatible arch string.

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -66,7 +66,7 @@ config:
     architecture:
       type: string
       default: ""
-      description: The image architecture to build for using external builder (i.e. amd64, arm64).
+      description: The image architecture to build for using external builder (i.e. amd64, arm64, s390x).
     base-image:
       type: string
       default: noble

--- a/src/state.py
+++ b/src/state.py
@@ -18,6 +18,7 @@ import pydantic
 logger = logging.getLogger(__name__)
 
 ARCHITECTURES_ARM64 = {"aarch64", "arm64"}
+ARCHITECTURES_S390x = {"s390x"}
 ARCHITECTURES_X86 = {"x86_64", "amd64"}
 CLOUD_NAME = "builder"
 LTS_IMAGE_VERSION_TAG_MAP = {"22.04": "jammy", "24.04": "noble"}
@@ -82,6 +83,7 @@ class Arch(str, Enum):
 
     ARM64 = "arm64"
     X64 = "x64"
+    S390x = "s390x"
 
     @classmethod
     def from_charm(cls, charm: ops.CharmBase) -> "Arch":


### PR DESCRIPTION
Applicable spec: ISD-200 S390x and ppc64el runners

### Overview

Add support for building an image on s390x architecture.

### Rationale

Teams would like to use runners on s390x.

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [ ] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `senior-review-required`, `documentation`)
- [ ] `RELEASE-NOTES.md` is updated (only for user-related changes)
<!-- Explanation for any unchecked items above -->
