### PR TITLE
Always install aproxy as it could be needed for the runner even if not needed in the builder

### DIFF
--- a/app/src/github_runner_image_builder/config.py
+++ b/app/src/github_runner_image_builder/config.py
@@ -107,7 +107,7 @@ IMAGE_DEFAULT_APT_PACKAGES = [
     "python3-pip",
     "python-is-python3",
     "shellcheck",
-    # socat is used for proxying between the github-runner manager and the runner.
+    # socat is used for proxying between the runner and the tmate-ssh-server.
     "socat",
     "tar",
     "time",

--- a/app/src/github_runner_image_builder/config.py
+++ b/app/src/github_runner_image_builder/config.py
@@ -107,6 +107,7 @@ IMAGE_DEFAULT_APT_PACKAGES = [
     "python3-pip",
     "python-is-python3",
     "shellcheck",
+    "socat",
     "tar",
     "time",
     "unzip",

--- a/app/src/github_runner_image_builder/config.py
+++ b/app/src/github_runner_image_builder/config.py
@@ -107,6 +107,7 @@ IMAGE_DEFAULT_APT_PACKAGES = [
     "python3-pip",
     "python-is-python3",
     "shellcheck",
+    # socat is used for proxying between the github-runner manager and the runner.
     "socat",
     "tar",
     "time",

--- a/app/src/github_runner_image_builder/templates/cloud-init.sh.j2
+++ b/app/src/github_runner_image_builder/templates/cloud-init.sh.j2
@@ -10,7 +10,7 @@ function configure_proxy() {
     local proxy="$1"
 
     echo "Installing aproxy"
-    # We always want snap aproxy and nft to be installed, even it they are not used by the image builder.
+    # We always want snap aproxy and nft (focal) to be installed, even it they are not used by the image builder.
     /usr/bin/sudo snap install aproxy --edge;
 
     if [ $RELEASE == "focal" ]; then

--- a/app/src/github_runner_image_builder/templates/cloud-init.sh.j2
+++ b/app/src/github_runner_image_builder/templates/cloud-init.sh.j2
@@ -10,8 +10,7 @@ function configure_proxy() {
     local proxy="$1"
 
     echo "Installing aproxy"
-    # We always want snap aproxy and nft to be installed, as it could be used by the runner,
-    # if the runner openstack project requires it.
+    # We always want snap aproxy and nft to be installed, even it they are not used by the image builder.
     /usr/bin/sudo snap install aproxy --edge;
 
     if [ $RELEASE == "focal" ]; then

--- a/app/src/github_runner_image_builder/templates/cloud-init.sh.j2
+++ b/app/src/github_runner_image_builder/templates/cloud-init.sh.j2
@@ -8,19 +8,26 @@ hostnamectl set-hostname github-runner
 
 function configure_proxy() {
     local proxy="$1"
-    if [[ -z "$proxy" ]]; then
-        return
-    fi
+
+    echo "Installing aproxy"
+    # We always want snap aproxy and nft to be installed, as it could be used by the runner,
+    # if the runner openstack project requires it.
+    /usr/bin/sudo snap install aproxy --edge;
 
     if [ $RELEASE == "focal" ]; then
         echo "Ensure nftables is installed on focal"
         # Focal does not have nftables install by default. Jammy and onward would not need this.
-        HTTP_PROXY=${proxy} HTTPS_PROXY=${proxy} NO_PROXY=127.0.0.1,localhost,::1,10.0.0.0/8,172.16.0.0/12,192.168.0.0/1 DEBIAN_FRONTEND=noninteractive /usr/bin/apt-get update -y
-        HTTP_PROXY=${proxy} HTTPS_PROXY=${proxy} NO_PROXY=127.0.0.1,localhost,::1,10.0.0.0/8,172.16.0.0/12,192.168.0.0/1 DEBIAN_FRONTEND=noninteractive /usr/bin/apt-get install -y --no-install-recommends nftables
+        HTTP_PROXY=${proxy:-} HTTPS_PROXY=${proxy:-} NO_PROXY=127.0.0.1,localhost,::1,10.0.0.0/8,172.16.0.0/12,192.168.0.0/1 DEBIAN_FRONTEND=noninteractive /usr/bin/apt-get update -y
+        HTTP_PROXY=${proxy:-} HTTPS_PROXY=${proxy:-} NO_PROXY=127.0.0.1,localhost,::1,10.0.0.0/8,172.16.0.0/12,192.168.0.0/1 DEBIAN_FRONTEND=noninteractive /usr/bin/apt-get install -y --no-install-recommends nftables
     fi
 
-    echo "Installing aproxy"
-    /usr/bin/sudo snap install aproxy --edge;
+    # Do not configure the proxy if it is not needed for building the image.
+    if [[ -z "$proxy" ]]; then
+	/usr/bin/sudo snap install aproxy --edge;
+        return
+    fi
+
+    echo "Configure nft and aproxy"
     /usr/bin/sudo nft -f - << EOF
 define default-ip = $(ip route get $(ip route show 0.0.0.0/0 | grep -oP 'via \K\S+') | grep -oP 'src \K\S+')
 define private-ips = { 10.0.0.0/8, 127.0.0.1/8, 172.16.0.0/12, 192.168.0.0/16 }

--- a/app/src/github_runner_image_builder/templates/cloud-init.sh.j2
+++ b/app/src/github_runner_image_builder/templates/cloud-init.sh.j2
@@ -10,7 +10,7 @@ function configure_proxy() {
     local proxy="$1"
 
     echo "Installing aproxy"
-    # We always want snap aproxy and nft (focal) to be installed, even it they are not used by the image builder.
+    # We always want snap aproxy and nft (in focal) to be installed, even it they are not used by the image builder.
     /usr/bin/sudo snap install aproxy --edge;
 
     if [ $RELEASE == "focal" ]; then

--- a/app/src/github_runner_image_builder/templates/cloud-init.sh.j2
+++ b/app/src/github_runner_image_builder/templates/cloud-init.sh.j2
@@ -23,7 +23,6 @@ function configure_proxy() {
 
     # Do not configure the proxy if it is not needed for building the image.
     if [[ -z "$proxy" ]]; then
-	/usr/bin/sudo snap install aproxy --edge;
         return
     fi
 

--- a/app/tests/unit/test_openstack_builder.py
+++ b/app/tests/unit/test_openstack_builder.py
@@ -669,36 +669,37 @@ hostnamectl set-hostname github-runner
 
 function configure_proxy() {{
     local proxy="$1"
-    if [[ -z "$proxy" ]]; then
-        return
-    fi
+
+    echo "Installing aproxy"
+    # We always want snap aproxy and nft to be installed, even it they are not used by the image builder.
+    /usr/bin/sudo snap install aproxy --edge;
 
     if [ $RELEASE == "focal" ]; then
         echo "Ensure nftables is installed on focal"
         # Focal does not have nftables install by default. Jammy and onward would not need this.
-        HTTP_PROXY=${{proxy}} HTTPS_PROXY=${{proxy}} \
-NO_PROXY=127.0.0.1,localhost,::1,10.0.0.0/8,172.16.0.0/12,192.168.0.0/1 \
-DEBIAN_FRONTEND=noninteractive /usr/bin/apt-get update -y
-        HTTP_PROXY=${{proxy}} HTTPS_PROXY=${{proxy}} \
-NO_PROXY=127.0.0.1,localhost,::1,10.0.0.0/8,172.16.0.0/12,192.168.0.0/1 \
-DEBIAN_FRONTEND=noninteractive /usr/bin/apt-get install -y --no-install-recommends nftables
+        HTTP_PROXY=${{proxy:-}} HTTPS_PROXY=${{proxy:-}} NO_PROXY=127.0.0.1,localhost,::1,10.0.0.0/8,172.16.0.0/12,192.168.0.0/1 DEBIAN_FRONTEND=noninteractive /usr/bin/apt-get update -y
+        HTTP_PROXY=${{proxy:-}} HTTPS_PROXY=${{proxy:-}} NO_PROXY=127.0.0.1,localhost,::1,10.0.0.0/8,172.16.0.0/12,192.168.0.0/1 DEBIAN_FRONTEND=noninteractive /usr/bin/apt-get install -y --no-install-recommends nftables
     fi
 
-    echo "Installing aproxy"
-    /usr/bin/sudo snap install aproxy --edge;
+    # Do not configure the proxy if it is not needed for building the image.
+    if [[ -z "$proxy" ]]; then
+        return
+    fi
+
+    echo "Configure nft and aproxy"
     /usr/bin/sudo nft -f - << EOF
-define default-ip = $(ip route get $(ip route show 0.0.0.0/0 | grep -oP 'via \\K\\S+') | grep -oP 'src \\K\\S+')
+define default-ip = $(ip route get $(ip route show 0.0.0.0/0 | grep -oP 'via \K\S+') | grep -oP 'src \K\S+')
 define private-ips = {{ 10.0.0.0/8, 127.0.0.1/8, 172.16.0.0/12, 192.168.0.0/16 }}
 table ip aproxy
 flush table ip aproxy
 table ip aproxy {{
         chain prerouting {{
                 type nat hook prerouting priority dstnat; policy accept;
-                ip daddr != \\$private-ips tcp dport {{ 80, 443 }} counter dnat to \\$default-ip:8444
+                ip daddr != \$private-ips tcp dport {{ 80, 443 }} counter dnat to \$default-ip:8444
         }}
         chain output {{
                 type nat hook output priority -100; policy accept;
-                ip daddr != \\$private-ips tcp dport {{ 80, 443 }} counter dnat to \\$default-ip:8444
+                ip daddr != \$private-ips tcp dport {{ 80, 443 }} counter dnat to \$default-ip:8444
         }}
 }}
 EOF

--- a/app/tests/unit/test_openstack_builder.py
+++ b/app/tests/unit/test_openstack_builder.py
@@ -657,7 +657,7 @@ def test__generate_cloud_init_script(
             proxy="test.proxy.internal:3128",
         )
         # The templated script contains similar lines to helper for setting up proxy.
-        # pylint: disable=R0801
+        # pylint: disable=R0801,C0301
         # Ignore bandit false positive on SQL injection vector.
         == f"""#!/bin/bash
 
@@ -688,18 +688,18 @@ function configure_proxy() {{
 
     echo "Configure nft and aproxy"
     /usr/bin/sudo nft -f - << EOF
-define default-ip = $(ip route get $(ip route show 0.0.0.0/0 | grep -oP 'via \K\S+') | grep -oP 'src \K\S+')
+define default-ip = $(ip route get $(ip route show 0.0.0.0/0 | grep -oP 'via \\K\\S+') | grep -oP 'src \\K\\S+')
 define private-ips = {{ 10.0.0.0/8, 127.0.0.1/8, 172.16.0.0/12, 192.168.0.0/16 }}
 table ip aproxy
 flush table ip aproxy
 table ip aproxy {{
         chain prerouting {{
                 type nat hook prerouting priority dstnat; policy accept;
-                ip daddr != \$private-ips tcp dport {{ 80, 443 }} counter dnat to \$default-ip:8444
+                ip daddr != \\$private-ips tcp dport {{ 80, 443 }} counter dnat to \\$default-ip:8444
         }}
         chain output {{
                 type nat hook output priority -100; policy accept;
-                ip daddr != \$private-ips tcp dport {{ 80, 443 }} counter dnat to \$default-ip:8444
+                ip daddr != \\$private-ips tcp dport {{ 80, 443 }} counter dnat to \\$default-ip:8444
         }}
 }}
 EOF
@@ -807,12 +807,11 @@ function configure_system_users() {{
 
 
 proxy="test.proxy.internal:3128"
-apt_packages="build-essential docker.io gh jq npm python3-dev python3-pip python-is-python3 shellcheck tar time unzip wget{
-    (' ' + ' '.join(additional_apt_packages)) if additional_apt_packages else ''}"
+apt_packages="build-essential docker.io gh jq npm python3-dev python3-pip python-is-python3 shellcheck tar time unzip wget{(' ' + ' '.join(additional_apt_packages)) if additional_apt_packages else ''}"
 hwe_version="22.04"
 github_runner_version=""
 github_runner_arch="{arch.value}"
-runner_binary_repo="{ expected_runner_binary_repo }"
+runner_binary_repo="{expected_runner_binary_repo}"
 
 configure_proxy "$proxy"
 install_apt_packages "$apt_packages" "$hwe_version"

--- a/app/tests/unit/test_openstack_builder.py
+++ b/app/tests/unit/test_openstack_builder.py
@@ -807,7 +807,7 @@ function configure_system_users() {{
 
 
 proxy="test.proxy.internal:3128"
-apt_packages="build-essential docker.io gh jq npm python3-dev python3-pip python-is-python3 shellcheck tar time unzip wget{(' ' + ' '.join(additional_apt_packages)) if additional_apt_packages else ''}"
+apt_packages="build-essential docker.io gh jq npm python3-dev python3-pip python-is-python3 shellcheck socat tar time unzip wget{(' ' + ' '.join(additional_apt_packages)) if additional_apt_packages else ''}"
 hwe_version="22.04"
 github_runner_version=""
 github_runner_arch="{arch.value}"

--- a/app/tests/unit/test_openstack_builder.py
+++ b/app/tests/unit/test_openstack_builder.py
@@ -670,7 +670,7 @@ function configure_proxy() {{
     local proxy="$1"
 
     echo "Installing aproxy"
-    # We always want snap aproxy and nft (focal)  to be installed, even it they are not used by the image builder.
+    # We always want snap aproxy and nft (in focal) to be installed, even it they are not used by the image builder.
     /usr/bin/sudo snap install aproxy --edge;
 
     if [ $RELEASE == "focal" ]; then

--- a/app/tests/unit/test_openstack_builder.py
+++ b/app/tests/unit/test_openstack_builder.py
@@ -656,8 +656,7 @@ def test__generate_cloud_init_script(
             ),
             proxy="test.proxy.internal:3128",
         )
-        # The templated script contains similar lines to helper for setting up proxy.
-        # pylint: disable=R0801,C0301
+        # pylint: disable=line-too-long
         # Ignore bandit false positive on SQL injection vector.
         == f"""#!/bin/bash
 
@@ -671,7 +670,7 @@ function configure_proxy() {{
     local proxy="$1"
 
     echo "Installing aproxy"
-    # We always want snap aproxy and nft to be installed, even it they are not used by the image builder.
+    # We always want snap aproxy and nft (focal)  to be installed, even it they are not used by the image builder.
     /usr/bin/sudo snap install aproxy --edge;
 
     if [ $RELEASE == "focal" ]; then


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->

The proxy for the image builder and the github-runner could be different. 

Even more, there could be two proxies in the github-runner, one for the manager and one for the runners.

We want to always install aproxy (and nft for focal), independently of the need for it in the image-builder. Otherwise we 
 ould have to copy the same code in the github-runner, and we careful with the proxy when installing aproxy and nft.

Besides that, we are also installing socat, as it could be needed in the github-runner for proxying tmate.

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `senior-review-required`, `documentation`)
- [x] `RELEASE-NOTES.md` is updated (only for user-related changes)
<!-- Explanation for any unchecked items above -->
