### PR TITLE
feat: ppc64le images

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -12,7 +12,7 @@ jobs:
     uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
     secrets: inherit
     with:
-      juju-channel: 3.2/stable
+      juju-channel: 3.6/stable
       provider: lxd
       modules: '["test_charm", "test_upgrade"]'
       self-hosted-runner: true

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -12,7 +12,7 @@ jobs:
     uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
     secrets: inherit
     with:
-      juju-channel: 3.6/stable
+      juju-channel: 3.2/stable
       provider: lxd
       modules: '["test_charm", "test_upgrade"]'
       self-hosted-runner: true

--- a/.github/workflows/integration_test_app.yaml
+++ b/.github/workflows/integration_test_app.yaml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         image: [focal, jammy, noble]
-        arch: [amd64, arm64, s390x]
+        arch: [amd64, arm64, s390x, ppc64le]
         exclude:
           - image: focal
             arch: s390x
@@ -23,6 +23,8 @@ jobs:
             arch: arm64
           - image: jammy
             arch: s390x
+          - image: noble
+            arch: ppc64le
     steps:
       - uses: actions/checkout@v4.2.2
       - uses: canonical/setup-lxd@v0.1.2
@@ -52,6 +54,13 @@ jobs:
             OPENSTACK_PASSWORD: ${{ secrets.OPENSTACK_PASSWORD_S390X }}
         run: |
          tox -e integration -- --arch s390x --image=${{ matrix.image }} ${{ secrets.INTEGRATION_TEST_ARGS_APP_S390X }}
+        working-directory: app
+      - name: Run integration tests (ppc64le)
+        if: matrix.arch == 'ppc64el'
+        env:
+            OPENSTACK_PASSWORD: ${{ secrets.OPENSTACK_PASSWORD_PPC64EL }}
+        run: |
+         tox -e integration -- --arch ppc64le --image=${{ matrix.image }} ${{ secrets.INTEGRATION_TEST_ARGS_APP_PPC64LE }}
         working-directory: app
   required_status_checks:
     name: Required Integration Test For Application Status Checks

--- a/.github/workflows/integration_test_app.yaml
+++ b/.github/workflows/integration_test_app.yaml
@@ -60,7 +60,7 @@ jobs:
       - name: Run integration tests (ppc64le)
         if: matrix.arch == 'ppc64le'
         env:
-            OPENSTACK_PASSWORD: ${{ secrets.OPENSTACK_PASSWORD_PPC64EL }}
+            OPENSTACK_PASSWORD: ${{ secrets.OPENSTACK_PASSWORD_PPC64LE }}
         run: |
          tox -e integration -- --arch ppc64le --image=${{ matrix.image }} ${{ secrets.INTEGRATION_TEST_ARGS_APP_PPC64LE }}
         working-directory: app

--- a/.github/workflows/integration_test_app.yaml
+++ b/.github/workflows/integration_test_app.yaml
@@ -18,13 +18,15 @@ jobs:
         arch: [amd64, arm64, s390x, ppc64le]
         exclude:
           - image: focal
+            arch: ppc64le
+          - image: focal
             arch: s390x
           - image: jammy
             arch: arm64
           - image: jammy
-            arch: s390x
-          - image: noble
             arch: ppc64le
+          - image: jammy
+            arch: s390x
     steps:
       - uses: actions/checkout@v4.2.2
       - uses: canonical/setup-lxd@v0.1.2
@@ -56,7 +58,7 @@ jobs:
          tox -e integration -- --arch s390x --image=${{ matrix.image }} ${{ secrets.INTEGRATION_TEST_ARGS_APP_S390X }}
         working-directory: app
       - name: Run integration tests (ppc64le)
-        if: matrix.arch == 'ppc64el'
+        if: matrix.arch == 'ppc64le'
         env:
             OPENSTACK_PASSWORD: ${{ secrets.OPENSTACK_PASSWORD_PPC64EL }}
         run: |

--- a/.github/workflows/promote_charm.yaml
+++ b/.github/workflows/promote_charm.yaml
@@ -7,11 +7,13 @@ on:
         type: choice
         description: 'Origin Channel'
         options:
+        - latest/beta
         - latest/edge
       destination-channel:
         type: choice
         description: 'Destination Channel'
         options:
+        - latest/beta
         - latest/stable
     secrets:
       CHARMHUB_TOKEN:

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -2,13 +2,13 @@
 > Add support for building ppc64le images.
 
 ### Upgrade Steps
-*  The architecture option has to be specified.
+*  Nothing in particular to consider. If PPC64LE architecture is desired, the config option `ppc64le` or `ppc64el` has to be specified.
 
 ### Breaking Changes
-* The charm expects the architecture to be specified in the configuration.
+* None
 
 ### New Features
-* The charm is now able to build images for the `ppc64le` architecture. `ppc64le` is not officially supported
+* The charm is now able to build images for the `ppc64le` (`ppc64el`) architecture. `ppc64le` is not officially supported
 by GitHub, but a fork of the actions runner binary has been created, which is used in the image. Note
 that ppc64le support is experimental and may be removed in the future.
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,3 +1,26 @@
+## [#101 feat: ppc64le images](https://github.com/canonical/github-runner-image-builder-operator/pull/101) (2025-04-02)
+> Add support for building ppc64le images.
+
+### Upgrade Steps
+*  The architecture option has to be specified.
+
+### Breaking Changes
+* The charm expects the architecture to be specified in the configuration.
+
+### New Features
+* The charm is now able to build images for the `ppc64le` architecture. `ppc64le` is not officially supported
+by GitHub, but a fork of the actions runner binary has been created, which is used in the image. Note
+that ppc64le support is experimental and may be removed in the future.
+
+### Bug Fixes
+* None
+
+### Performance Improvements
+* None
+
+### Other Changes
+* None
+* 
 ## [#91 Feature: Add focal support](https://github.com/canonical/github-runner-image-builder-operator/pull/91) (2025-03-07)
 > Add support for building focal images.
 

--- a/app/src/github_runner_image_builder/cli.py
+++ b/app/src/github_runner_image_builder/cli.py
@@ -33,7 +33,9 @@ def main(log_level: str | int) -> None:
 @main.command(name="init")
 @click.option(
     "--arch",
-    type=click.Choice((config.Arch.ARM64, config.Arch.X64, config.Arch.S390X)),
+    type=click.Choice(
+        (config.Arch.ARM64, config.Arch.X64, config.Arch.S390X, config.Arch.PPC64LE)
+    ),
     help="Image architecture to initialize for.",
     required=True,
 )
@@ -112,7 +114,9 @@ def _parse_url(
 @click.argument("image_name")
 @click.option(
     "--arch",
-    type=click.Choice((config.Arch.ARM64, config.Arch.X64, config.Arch.S390X)),
+    type=click.Choice(
+        (config.Arch.ARM64, config.Arch.X64, config.Arch.S390X, config.Arch.PPC64LE)
+    ),
     help="Image architecture.",
     required=True,
 )

--- a/app/src/github_runner_image_builder/cloud_image.py
+++ b/app/src/github_runner_image_builder/cloud_image.py
@@ -83,7 +83,7 @@ def _get_supported_runner_arch(arch: Arch) -> SupportedBaseImageArch:
         case Arch.S390X:
             return "s390x"
         case Arch.PPC64LE:
-            return "ppc64le"
+            return "ppc64el" # cloud-images.ubuntu.com uses ppc64el instead of ppc64le
         case _:
             raise UnsupportedArchitectureError(f"Detected system arch: {arch} is unsupported.")
 

--- a/app/src/github_runner_image_builder/cloud_image.py
+++ b/app/src/github_runner_image_builder/cloud_image.py
@@ -19,7 +19,7 @@ from github_runner_image_builder.utils import retry
 
 logger = logging.getLogger(__name__)
 
-SupportedBaseImageArch = typing.Literal["amd64", "arm64", "s390x"]
+SupportedBaseImageArch = typing.Literal["amd64", "arm64", "s390x", "ppc64le"]
 
 CHECKSUM_BUF_SIZE = 65536  # 65kb
 
@@ -82,6 +82,8 @@ def _get_supported_runner_arch(arch: Arch) -> SupportedBaseImageArch:
             return "arm64"
         case Arch.S390X:
             return "s390x"
+        case Arch.PPC64LE:
+            return "ppc64le"
         case _:
             raise UnsupportedArchitectureError(f"Detected system arch: {arch} is unsupported.")
 

--- a/app/src/github_runner_image_builder/cloud_image.py
+++ b/app/src/github_runner_image_builder/cloud_image.py
@@ -19,7 +19,7 @@ from github_runner_image_builder.utils import retry
 
 logger = logging.getLogger(__name__)
 
-SupportedBaseImageArch = typing.Literal["amd64", "arm64", "s390x", "ppc64le"]
+SupportedBaseImageArch = typing.Literal["amd64", "arm64", "s390x", "ppc64el"]
 
 CHECKSUM_BUF_SIZE = 65536  # 65kb
 
@@ -83,7 +83,7 @@ def _get_supported_runner_arch(arch: Arch) -> SupportedBaseImageArch:
         case Arch.S390X:
             return "s390x"
         case Arch.PPC64LE:
-            return "ppc64el" # cloud-images.ubuntu.com uses ppc64el instead of ppc64le
+            return "ppc64el"  # cloud-images.ubuntu.com uses ppc64el instead of ppc64le
         case _:
             raise UnsupportedArchitectureError(f"Detected system arch: {arch} is unsupported.")
 

--- a/app/src/github_runner_image_builder/config.py
+++ b/app/src/github_runner_image_builder/config.py
@@ -19,7 +19,7 @@ class Arch(str, Enum):
         ARM64: Represents an ARM64 system architecture.
         X64: Represents an X64/AMD64 system architecture.
         S390X: Represents an S390X system architecture.
-        PPC64LE: Represents an PPC64LE system architecture.
+        PPC64LE: Represents a PPC64LE system architecture.
     """
 
     ARM64 = "arm64"

--- a/app/src/github_runner_image_builder/config.py
+++ b/app/src/github_runner_image_builder/config.py
@@ -19,11 +19,13 @@ class Arch(str, Enum):
         ARM64: Represents an ARM64 system architecture.
         X64: Represents an X64/AMD64 system architecture.
         S390X: Represents an S390X system architecture.
+        PPC64LE: Represents an PPC64LE system architecture.
     """
 
     ARM64 = "arm64"
     X64 = "x64"
     S390X = "s390x"
+    PPC64LE = "ppc64le"
 
     def to_openstack(self) -> str:
         """Convert the architecture to OpenStack compatible arch string.
@@ -38,6 +40,8 @@ class Arch(str, Enum):
                 return "x86_64"
             case Arch.S390X:
                 return "s390x"
+            case Arch.PPC64LE:
+                return "ppc64le"
         raise ValueError  # pragma: nocover
 
 
@@ -114,7 +118,7 @@ IMAGE_DEFAULT_APT_PACKAGES = [
     "unzip",
     "wget",
 ]
-S390X_ADDITIONAL_APT_PACKAGES = ["dotnet-runtime-8.0"]
+S390X_PPC64LE_ADDITIONAL_APT_PACKAGES = ["dotnet-runtime-8.0"]
 
 _LOG_LEVELS = (logging.DEBUG, logging.INFO, logging.WARNING, logging.ERROR)
 LOG_LEVELS = tuple(

--- a/app/src/github_runner_image_builder/openstack_builder.py
+++ b/app/src/github_runner_image_builder/openstack_builder.py
@@ -41,7 +41,7 @@ from github_runner_image_builder import cloud_image, config, store
 from github_runner_image_builder.config import (
     FORK_RUNNER_BINARY_REPO,
     IMAGE_DEFAULT_APT_PACKAGES,
-    S390X_ADDITIONAL_APT_PACKAGES,
+    S390X_PPC64LE_ADDITIONAL_APT_PACKAGES,
     UPSTREAM_RUNNER_BINARY_REPO,
     Arch,
     BaseImage,
@@ -514,8 +514,8 @@ def _generate_cloud_init_script(
     template = env.get_template("cloud-init.sh.j2")
 
     apt_packages = IMAGE_DEFAULT_APT_PACKAGES
-    if image_config.arch == Arch.S390X:
-        apt_packages = IMAGE_DEFAULT_APT_PACKAGES + S390X_ADDITIONAL_APT_PACKAGES
+    if image_config.arch in (Arch.S390X, Arch.PPC64LE):
+        apt_packages = IMAGE_DEFAULT_APT_PACKAGES + S390X_PPC64LE_ADDITIONAL_APT_PACKAGES
         runner_binary_repo = FORK_RUNNER_BINARY_REPO
     else:
         runner_binary_repo = UPSTREAM_RUNNER_BINARY_REPO

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -42,7 +42,7 @@ def pytest_addoption(parser: Parser):
         "--arch",
         action="store",
         help="The architecture to build for.",
-        choices=["amd64", "arm64", "s390x"],
+        choices=["amd64", "arm64", "s390x", "ppc64le"],
     )
     parser.addoption(
         "--openstack-network-name",

--- a/app/tests/integration/conftest.py
+++ b/app/tests/integration/conftest.py
@@ -36,6 +36,8 @@ def arch_fixture(pytestconfig: pytest.Config):
             return config.Arch.X64
         case "s390x":
             return config.Arch.S390X
+        case "ppc64le":
+            return config.Arch.PPC64LE
     raise ValueError(f"Unsupported testing architecture {arch}")
 
 

--- a/app/tests/unit/test_cli.py
+++ b/app/tests/unit/test_cli.py
@@ -84,6 +84,7 @@ def test_main(cli_runner: CliRunner, action: str):
         pytest.param("arm64", config.Arch.ARM64, id="arm64"),
         pytest.param("x64", config.Arch.X64, id="amd64"),
         pytest.param("s390x", config.Arch.S390X, id="s390x"),
+        pytest.param("ppc64le", config.Arch.PPC64LE, id="ppc64le"),
     ],
 )
 def test_initialize(

--- a/app/tests/unit/test_cloud_image.py
+++ b/app/tests/unit/test_cloud_image.py
@@ -158,6 +158,7 @@ def test__get_supported_runner_arch_unsupported_error():
         pytest.param(Arch.ARM64, "arm64", id="ARM64"),
         pytest.param(Arch.X64, "amd64", id="AMD64"),
         pytest.param(Arch.S390X, "s390x", id="S390X"),
+        pytest.param(Arch.PPC64LE, "ppc64le", id="PPC64LE"),
     ],
 )
 def test__get_supported_runner_arch(arch: Arch, expected: SupportedBaseImageArch):

--- a/app/tests/unit/test_cloud_image.py
+++ b/app/tests/unit/test_cloud_image.py
@@ -158,7 +158,7 @@ def test__get_supported_runner_arch_unsupported_error():
         pytest.param(Arch.ARM64, "arm64", id="ARM64"),
         pytest.param(Arch.X64, "amd64", id="AMD64"),
         pytest.param(Arch.S390X, "s390x", id="S390X"),
-        pytest.param(Arch.PPC64LE, "ppc64le", id="PPC64LE"),
+        pytest.param(Arch.PPC64LE, "ppc64el", id="PPC64LE"),
     ],
 )
 def test__get_supported_runner_arch(arch: Arch, expected: SupportedBaseImageArch):

--- a/app/tests/unit/test_config.py
+++ b/app/tests/unit/test_config.py
@@ -21,6 +21,7 @@ from github_runner_image_builder.config import (
         pytest.param(Arch.ARM64, "aarch64", id="arm64"),
         pytest.param(Arch.X64, "x86_64", id="amd64"),
         pytest.param(Arch.S390X, "s390x", id="s390x"),
+        pytest.param(Arch.PPC64LE, "ppc64le", id="ppc64le"),
     ],
 )
 def test_arch_openstack_conversion(arch: Arch, expected: str):

--- a/app/tests/unit/test_openstack_builder.py
+++ b/app/tests/unit/test_openstack_builder.py
@@ -630,6 +630,12 @@ def test__determine_network(network_name: str | None):
             ["dotnet-runtime-8.0"],
             id="s390x",
         ),
+        pytest.param(
+            openstack_builder.Arch.PPC64LE,
+            "canonical/github-actions-runner",
+            ["dotnet-runtime-8.0"],
+            id="ppc64le",
+        ),
     ],
 )
 def test__generate_cloud_init_script(

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -66,7 +66,8 @@ config:
     architecture:
       type: string
       description: |
-        The image architecture to build for using external builder. Can be one of "amd64", "arm64", "s390x", "ppc64el".
+        The image architecture to build for using external builder. Can be one of "amd64", "arm64", "s390x", 
+        "ppc64le" (alternatively "ppc64el").
         Support for "s390x" and "ppc64el" is considered experimental.
     base-image:
       type: string

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -66,8 +66,8 @@ config:
     architecture:
       type: string
       description: |
-        The image architecture to build for using external builder. Can be one of "amd64", "arm64", "s390x".
-        Support for "s390x" is considered experimental.
+        The image architecture to build for using external builder. Can be one of "amd64", "arm64", "s390x", "ppc64el".
+        Support for "s390x" and "ppc64el" is considered experimental.
     base-image:
       type: string
       default: noble

--- a/src/state.py
+++ b/src/state.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 
 ARCHITECTURES_ARM64 = {"aarch64", "arm64"}
 ARCHITECTURES_S390x = {"s390x"}
-ARCHITECTURES_PPC64LE = {"ppc64le"}
+ARCHITECTURES_PPC64LE = {"ppc64le", "ppc64el"}
 ARCHITECTURES_X86 = {"x86_64", "amd64", "x64"}
 CLOUD_NAME = "builder"
 LTS_IMAGE_VERSION_TAG_MAP = {"20.04": "focal", "22.04": "jammy", "24.04": "noble"}

--- a/src/state.py
+++ b/src/state.py
@@ -18,6 +18,7 @@ logger = logging.getLogger(__name__)
 
 ARCHITECTURES_ARM64 = {"aarch64", "arm64"}
 ARCHITECTURES_S390x = {"s390x"}
+ARCHITECTURES_PPC64LE = {"ppc64le"}
 ARCHITECTURES_X86 = {"x86_64", "amd64", "x64"}
 CLOUD_NAME = "builder"
 LTS_IMAGE_VERSION_TAG_MAP = {"20.04": "focal", "22.04": "jammy", "24.04": "noble"}
@@ -71,6 +72,7 @@ class Arch(str, Enum):
         ARM64: Represents an ARM64 system architecture.
         X64: Represents an X64/AMD64 system architecture.
         S390X: Represents an S390X system architecture.
+        PPC64LE: Represents an PPC64LE system architecture.
     """
 
     def __str__(self) -> str:
@@ -84,6 +86,7 @@ class Arch(str, Enum):
     ARM64 = "arm64"
     X64 = "x64"
     S390X = "s390x"
+    PPC64LE = "ppc64le"
 
     @classmethod
     def from_charm(cls, charm: ops.CharmBase) -> "Arch":
@@ -108,6 +111,8 @@ class Arch(str, Enum):
                 return Arch.X64
             case arch if arch in ARCHITECTURES_S390x:
                 return Arch.S390X
+            case arch if arch in ARCHITECTURES_PPC64LE:
+                return Arch.PPC64LE
             case _:
                 raise UnsupportedArchitectureError(msg=f"Unsupported {arch=}")
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -145,6 +145,8 @@ def arch_fixture(pytestconfig: pytest.Config):
             return state.Arch.X64
         case "s390x":
             return state.Arch.S390X
+        case "ppc64le":
+            return state.Arch.PPC64LE
     raise ValueError(f"Unsupported testing architecture {arch}")
 
 

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -46,6 +46,7 @@ async def test_cos_agent_relation(app: Application):
         "grafana-agent",
         application_name=f"grafana-agent-{app.name}",
         channel="latest/edge",
+        base="ubuntu@22.04"
     )
     await model.relate(f"{app.name}:cos-agent", f"{grafana_agent.name}:cos-agent")
     await model.wait_for_idle(apps=[app.name], status="active", timeout=30 * 60)

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -46,7 +46,7 @@ async def test_cos_agent_relation(app: Application):
         "grafana-agent",
         application_name=f"grafana-agent-{app.name}",
         channel="latest/edge",
-        base="ubuntu@22.04"
+        series="jammy"
     )
     await model.relate(f"{app.name}:cos-agent", f"{grafana_agent.name}:cos-agent")
     await model.wait_for_idle(apps=[app.name], status="active", timeout=30 * 60)

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -46,7 +46,7 @@ async def test_cos_agent_relation(app: Application):
         "grafana-agent",
         application_name=f"grafana-agent-{app.name}",
         channel="latest/edge",
-        series="jammy"
+        series="jammy",
     )
     await model.relate(f"{app.name}:cos-agent", f"{grafana_agent.name}:cos-agent")
     await model.wait_for_idle(apps=[app.name], status="active", timeout=30 * 60)

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -40,6 +40,7 @@ def patch_juju_version_29_fixture(monkeypatch: pytest.MonkeyPatch):
         pytest.param("arm64", state.Arch.ARM64, id="arm64"),
         pytest.param("amd64", state.Arch.X64, id="amd64"),
         pytest.param("s390x", state.Arch.S390X, id="s390x"),
+        pytest.param("ppc64le", state.Arch.PPC64LE, id="ppc64le"),
     ],
 )
 def test_arch_from_charm(arch: str, expected: state.Arch):
@@ -61,12 +62,12 @@ def test_arch_from_charm_unsupported():
     assert: UnsupportedArchitectureError is raised.
     """
     charm = factories.MockCharmFactory()
-    charm.config[state.ARCHITECTURE_CONFIG_NAME] = "ppc64le"
+    charm.config[state.ARCHITECTURE_CONFIG_NAME] = "invalid"
 
     with pytest.raises(state.UnsupportedArchitectureError) as exc:
         state.Arch.from_charm(charm=charm)
 
-    assert "ppc64le" in str(exc.getrepr())
+    assert "invalid" in str(exc.getrepr())
 
 
 @pytest.mark.parametrize(
@@ -75,6 +76,7 @@ def test_arch_from_charm_unsupported():
         pytest.param(state.Arch.ARM64, state.Arch.ARM64.value),
         pytest.param(state.Arch.X64, state.Arch.X64.value),
         pytest.param(state.Arch.S390X, state.Arch.S390X.value),
+        pytest.param(state.Arch.PPC64LE, state.Arch.PPC64LE.value),
     ],
 )
 def test_arch_str(arch: state.Arch, expected_str: str):


### PR DESCRIPTION
Applicable spec: [ISD-200](https://docs.google.com/document/d/1voLbTHbtUbLlVbOx8VgsBotqXBnMLzMi2nBmmbCQ9aY/edit?tab=t.0)

### Overview

Add support for building an image on ppc64le architecture. Similar adaptions as done in https://github.com/canonical/github-runner-image-builder-operator/pull/83.

### Rationale

Teams would like to use runners on ppc64el.

### Juju Events Changes

n/a

### Module Changes

Add `ppc64le` support to various places. Do support specifying `ppc64el` per config option, too, as this is the notation in the ubuntu/debian universe.

### Library Changes

n/a

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `senior-review-required`, `documentation`)
- [x] `RELEASE-NOTES.md` is updated (only for user-related changes)
<!-- Explanation for any unchecked items above -->


[ISD-200]: https://warthogs.atlassian.net/browse/ISD-200?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ