### PR TITLE
chore: reset openstackstdk to upstream

### DIFF
--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -1,7 +1,7 @@
 click==8.1.8
 fabric==3.2.2
 Jinja2==3.1.6
-openstacksdk @ git+https://github.com/yanksyoon/openstacksdk.git@fix/download_image_stream
+openstacksdk==4.5.0
 pyyaml==6.0.2
 tenacity==9.1.2
 typing_extensions==4.13.1


### PR DESCRIPTION
Applicable spec: <link>

### Overview

The streaming image download is now supported and is released on OpenStack SDK v4.5.0 and we can start using that now :)
<!-- A high level overview of the change -->

### Rationale

Keep following upstream rather than fork.

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `senior-review-required`, `documentation`)
- [ ] The docs/changelog.md is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
No user relevant changes