### PR TITLE
fix: image builder doc link in charmcraft.yaml

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -14,7 +14,7 @@ description: |
   latest version of the images.
 links:
   contact: https://github.com/orgs/canonical/teams/is-charms
-  documentation: https://discourse.charmhub.io/t/github-runner-image-builder-documentation-overview
+  documentation: https://discourse.charmhub.io/t/github-runner-image-builder-documentation-overview/15390
   issues: https://github.com/canonical/github-runner-image-builder-operator/issues
   source: https://github.com/canonical/github-runner-image-builder-operator
   website: https://charmhub.io/github-runner-image-builder


### PR DESCRIPTION
Applicable spec: <link>

### Overview

Fix the image builder doc link

### Rationale

The documentation is not displayed in https://charmhub.io/github-runner-image-builder



### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `senior-review-required`, `documentation`)
- [x] The docs/changelog.md is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
