### PR TITLE
fix: skip run if relation data is not ready

### DIFF
--- a/app/src/github_runner_image_builder/openstack_builder.py
+++ b/app/src/github_runner_image_builder/openstack_builder.py
@@ -243,8 +243,7 @@ class CloudConfig:
         network: The OpenStack network to launch the builder VMs on.
         prefix: The prefix to use for OpenStack resource names.
         proxy: The proxy to enable on builder VMs.
-        upload_cloud_names: The OpenStack cloud names to upload the snapshot to. (Defaults to \
-            the same cloud)
+        upload_cloud_names: The OpenStack cloud names to upload the snapshot to.
     """
 
     cloud_name: str

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,3 +1,24 @@
+## [#113 fix: skip run if relation data is not ready](https://github.com/canonical/github-runner-image-builder-operator/pull/113)
+> Fix: Skip image build run if relation data is not ready
+
+### Upgrade Steps
+*  Nothing in particular to consider.
+
+### Breaking Changes
+* None
+
+### New Features
+* None
+
+### Bug Fixes
+* Fixed unnecessary image build runs where unit relation data was not ready.
+
+### Performance Improvements
+* Image build propagation to newly joined units should be faster.
+
+### Other Changes
+* None
+* 
 ## [#101 feat: ppc64le images](https://github.com/canonical/github-runner-image-builder-operator/pull/101) (2025-04-02)
 > Add support for building ppc64le images.
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,24 +1,13 @@
 ## [#113 fix: skip run if relation data is not ready](https://github.com/canonical/github-runner-image-builder-operator/pull/113)
 > Fix: Skip image build run if relation data is not ready
 
-### Upgrade Steps
-*  Nothing in particular to consider.
-
-### Breaking Changes
-* None
-
-### New Features
-* None
-
 ### Bug Fixes
 * Fixed unnecessary image build runs where unit relation data was not ready.
 
 ### Performance Improvements
 * Image build propagation to newly joined units should be faster.
 
-### Other Changes
-* None
-* 
+
 ## [#101 feat: ppc64le images](https://github.com/canonical/github-runner-image-builder-operator/pull/101) (2025-04-02)
 > Add support for building ppc64le images.
 

--- a/docs/explanation/charm-architecture.md
+++ b/docs/explanation/charm-architecture.md
@@ -5,7 +5,6 @@ that creates and stores VM images suitable for use by self-hosted GitHub Runners
 The image-builder source code is hosted in the [github-runner-image-builder GitHub repository](https://github.com/canonical/github-runner-image-builder).
 
 ```mermaid
-
 C4Container
 title Container diagram for Image Builder System
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -73,9 +73,7 @@ class GithubRunnerImageBuilderCharm(ops.CharmBase):
     def _on_config_changed(self, _: ops.ConfigChangedEvent) -> None:
         """Handle charm configuration change events."""
         builder_config_state = state.BuilderConfig.from_charm(charm=self)
-        if not self._is_image_relation_ready_set_status(
-            cloud_config=builder_config_state.cloud_config
-        ):
+        if not self._is_any_image_relation_ready(cloud_config=builder_config_state.cloud_config):
             return
         # The following lines should be covered by integration tests.
         proxy.configure_aproxy(proxy=state.ProxyConfig.from_env())  # pragma: no cover
@@ -116,9 +114,7 @@ class GithubRunnerImageBuilderCharm(ops.CharmBase):
     def _on_run(self, _: RunEvent) -> None:
         """Handle the run event."""
         builder_config_state = state.BuilderConfig.from_charm(charm=self)
-        if not self._is_image_relation_ready_set_status(
-            cloud_config=builder_config_state.cloud_config
-        ):
+        if not self._is_any_image_relation_ready(cloud_config=builder_config_state.cloud_config):
             return
         # The following line should be covered by the integration test.
         self._run()  # pragma: nocover
@@ -131,9 +127,7 @@ class GithubRunnerImageBuilderCharm(ops.CharmBase):
             event: The run action event.
         """
         builder_config_state = state.BuilderConfig.from_charm(charm=self)
-        if not self._is_image_relation_ready_set_status(
-            cloud_config=builder_config_state.cloud_config
-        ):
+        if not self._is_any_image_relation_ready(cloud_config=builder_config_state.cloud_config):
             event.fail("Image relation not yet ready.")
             return
         # The following line should be covered by the integration test.
@@ -153,8 +147,8 @@ class GithubRunnerImageBuilderCharm(ops.CharmBase):
             )
         )
 
-    def _is_image_relation_ready_set_status(self, cloud_config: state.CloudConfig) -> bool:
-        """Check if image relation is ready and set according status otherwise.
+    def _is_any_image_relation_ready(self, cloud_config: state.CloudConfig) -> bool:
+        """Check if any of the image relations is ready and set according status otherwise.
 
         Args:
             cloud_config: The cloud configuration state.

--- a/src/charm.py
+++ b/src/charm.py
@@ -6,6 +6,7 @@
 """Entrypoint for GithubRunnerImageBuilder charm."""
 
 import logging
+import time
 import typing
 
 import ops
@@ -173,6 +174,7 @@ class GithubRunnerImageBuilderCharm(ops.CharmBase):
             cloud_id: The cloud ID to upload the image to. If None, the image will be uploaded to
                 all clouds.
         """
+        start_ts = time.time()
         self.unit.status = ops.ActiveStatus("Building image.")
         logger.info(f"Building image and uploading to {cloud_id if cloud_id else 'all clouds'}.")
         builder_config = state.BuilderConfig.from_charm(self)
@@ -186,6 +188,10 @@ class GithubRunnerImageBuilderCharm(ops.CharmBase):
         )
         self.image_observer.update_image_data(cloud_images=cloud_images)
         self.unit.status = ops.ActiveStatus()
+        end_ts = time.time()
+        logger.info(
+            f"Image build and upload completed in {end_ts - start_ts:.2f} seconds."
+        )
 
     def _get_configuration_matrix(
         self, builder_config: state.BuilderConfig

--- a/src/charm.py
+++ b/src/charm.py
@@ -187,8 +187,16 @@ class GithubRunnerImageBuilderCharm(ops.CharmBase):
         )
         self.image_observer.update_image_data(cloud_images=cloud_images)
         self.unit.status = ops.ActiveStatus()
-        end_ts = time.time()
-        logger.info("Image build and upload completed in %.2f seconds.", end_ts - start_ts)
+        duration = time.time() - start_ts
+        logger.info(
+            {
+                "log_type": "image_build",
+                "duration": duration,
+                "cloud_images_count": len(cloud_images),
+                "arch": builder_config.image_config.arch,
+                "bases": builder_config.image_config.bases,
+            }
+        )
 
     def _get_configuration_matrix(
         self, builder_config: state.BuilderConfig

--- a/src/charm.py
+++ b/src/charm.py
@@ -4,7 +4,7 @@
 # See LICENSE file for licensing details.
 
 """Entrypoint for GithubRunnerImageBuilder charm."""
-
+import json
 import logging
 import time
 import typing
@@ -189,13 +189,15 @@ class GithubRunnerImageBuilderCharm(ops.CharmBase):
         self.unit.status = ops.ActiveStatus()
         duration = time.time() - start_ts
         logger.info(
-            {
-                "log_type": "image_build",
-                "duration": duration,
-                "cloud_images_count": len(cloud_images),
-                "arch": builder_config.image_config.arch,
-                "bases": builder_config.image_config.bases,
-            }
+            json.dumps(
+                {
+                    "log_type": "image_build",
+                    "duration": duration,
+                    "cloud_images_count": len(cloud_images),
+                    "arch": builder_config.image_config.arch,
+                    "bases": builder_config.image_config.bases,
+                }
+            )
         )
 
     def _get_configuration_matrix(

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -54,7 +54,18 @@ def test_hooks_that_trigger_run_for_all_clouds(
     act: when the hook is called.
     assert: the charm falls into ActiveStatus
     """
-    monkeypatch.setattr(state.BuilderConfig, "from_charm", MagicMock())
+    image_config = state.ImageConfig(
+        arch=state.Arch.ARM64,
+        bases=(state.BaseImage.FOCAL,),
+        runner_version="",
+        script_url=None,
+        script_secrets=dict(),
+    )
+    monkeypatch.setattr(
+        state.BuilderConfig,
+        "from_charm",
+        MagicMock(return_value=MagicMock(image_config=image_config)),
+    )
     monkeypatch.setattr(proxy, "configure_aproxy", MagicMock())
     monkeypatch.setattr(builder, "install_clouds_yaml", MagicMock())
     monkeypatch.setattr(builder, "run", MagicMock())
@@ -131,7 +142,18 @@ def test__on_image_relation_changed(
     act: when _on_image_relation_changed is called.
     assert: charm is in active status and run for the particular related unit is called.
     """
-    monkeypatch.setattr(state.BuilderConfig, "from_charm", MagicMock())
+    image_config = state.ImageConfig(
+        arch=state.Arch.ARM64,
+        bases=(state.BaseImage.FOCAL,),
+        runner_version="",
+        script_url=None,
+        script_secrets=dict(),
+    )
+    monkeypatch.setattr(
+        state.BuilderConfig,
+        "from_charm",
+        MagicMock(return_value=MagicMock(image_config=image_config)),
+    )
     monkeypatch.setattr(proxy, "configure_aproxy", MagicMock())
     monkeypatch.setattr(builder, "install_clouds_yaml", MagicMock())
     monkeypatch.setattr(builder, "run", MagicMock())

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -100,31 +100,33 @@ def test__on_image_relation_changed(
     """
     arrange: given monkeypatched builder, openstack manager, image_observer.
     act: when _on_image_relation_changed is called.
-    assert: charm is in active status.
+    assert: charm is in active status and run for the particular related unit is called.
     """
     monkeypatch.setattr(state.BuilderConfig, "from_charm", MagicMock())
     monkeypatch.setattr(proxy, "configure_aproxy", MagicMock())
     monkeypatch.setattr(builder, "install_clouds_yaml", MagicMock())
     monkeypatch.setattr(builder, "run", MagicMock())
     charm.image_observer = MagicMock()
+    fake_clouds_auth_config = state.CloudsAuthConfig(
+        auth_url="http://example.com",
+        username="user",
+        password="pass",
+        project_name="project_name",
+        project_domain_name="project_domain_name",
+        user_domain_name="user_domain_name",
+    )
     monkeypatch.setattr(
         state.CloudsAuthConfig,
         "from_unit_relation_data",
-        MagicMock(
-            return_value=state.CloudsAuthConfig(
-                auth_url="http://example.com",
-                username="user",
-                password="pass",
-                project_name="project_name",
-                project_domain_name="project_domain_name",
-                user_domain_name="user_domain_name",
-            )
-        ),
+        MagicMock(return_value=fake_clouds_auth_config),
     )
 
     charm._on_image_relation_changed(MagicMock())
 
     assert charm.unit.status == ops.ActiveStatus()
+    assert builder.run.call_args[1]["static_config"].cloud_config.upload_clouds == [
+        fake_clouds_auth_config.get_id()
+    ]
 
 
 def test__on_image_relation_changed_no_unit_auth_data(

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -19,7 +19,7 @@ import state
 from charm import GithubRunnerImageBuilderCharm
 
 
-@pytest.fixture(autouse=True, name="mock_builder")
+@pytest.fixture(name="mock_builder")
 def mock_builder_fixture(monkeypatch: pytest.MonkeyPatch):
     """Mock builder functions to avoid actual image building."""
     image_config = state.ImageConfig(
@@ -58,6 +58,7 @@ def test_block_on_image_relation_not_ready(charm: GithubRunnerImageBuilderCharm,
     assert charm.unit.status == ops.BlockedStatus(f"{state.IMAGE_RELATION} integration required.")
 
 
+@pytest.mark.usefixtures("mock_builder")
 @pytest.mark.parametrize(
     "hook",
     [
@@ -139,6 +140,7 @@ def test_installation(
     assert charm.unit.status == ops.ActiveStatus(expected_active_msg)
 
 
+@pytest.mark.usefixtures("mock_builder")
 def test__on_image_relation_changed(
     monkeypatch: pytest.MonkeyPatch, charm: GithubRunnerImageBuilderCharm
 ):
@@ -171,6 +173,7 @@ def test__on_image_relation_changed(
     ]
 
 
+@pytest.mark.usefixtures("mock_builder")
 @pytest.mark.parametrize(
     "with_unit",
     [


### PR DESCRIPTION
Applicable spec: <link>

### Overview

Only run image building on a relation changed event if there is cloud auth data present. Only upload the newly created image to this particular cloud.

### Rationale

We have observed long waiting periods for new GitHub Runner units for the image to be present. In particular, the image build ran despite having cloud authentication data. Additionally, uploading images to all other units took some time.
```
2025-04-09 11:45:31 INFO juju.worker.uniter.operation runhook.go:186 ran "image-relation-created" hook (via hook dispatching script: dispatch)
2025-04-09 13:48:44.771	
2025-04-09 11:48:44 INFO unit.image-builder-noble-amd64-ps6/0.juju-log server.go:325 image:385: Required relation data not yet set.
2025-04-09 13:48:44.771	
2025-04-09 11:48:44 WARNING unit.image-builder-noble-amd64-ps6/0.juju-log server.go:325 image:385: Required field not yet set on reactive-amd64-noble-large-ps7/0.
2025-04-09 13:48:44.771	
2025-04-09 11:48:44 INFO unit.image-builder-noble-amd64-ps6/0.juju-log server.go:325 image:385: Required relation data not yet set.
2025-04-09 13:48:44.771	
2025-04-09 11:48:44 WARNING unit.image-builder-noble-amd64-ps6/0.juju-log server.go:325 image:385: Unit relation data not yet ready.
2025-04-09 13:48:45.021	
2025-04-09 11:48:44 INFO juju.worker.uniter.operation runhook.go:186 ran "image-relation-joined" hook (via hook dispatching script: dispatch)
2025-04-09 13:48:45.522	
2025-04-09 11:48:45 INFO unit.image-builder-noble-amd64-ps6/0.juju-log server.go:325 image:385: Required relation data not yet set.
2025-04-09 13:48:45.522	
2025-04-09 11:48:45 WARNING unit.image-builder-noble-amd64-ps6/0.juju-log server.go:325 image:385: Required field not yet set on reactive-amd64-noble-large-ps7/0.
2025-04-09 13:48:46.774	
2025-04-09 11:48:46 INFO unit.image-builder-noble-amd64-ps6/0.juju-log server.go:325 image:385: Required relation data not yet set.
2025-04-09 13:48:46.774	
2025-04-09 11:48:46 WARNING unit.image-builder-noble-amd64-ps6/0.juju-log server.go:325 image:385: Required field not yet set on reactive-amd64-noble-large-ps7/0.
2025-04-09 13:48:46.774	
2025-04-09 11:48:46 INFO unit.image-builder-noble-amd64-ps6/0.juju-log server.go:325 image:385: Run build command: ['/usr/bin/run-one', '/usr/bin/sudo', '--preserve-env', '/home/ubuntu/.local/bin/github-runner-image-builder', 'run', 'builder','REDACTED']
2025-04-09 14:25:17.350	
2025-04-09 12:25:17 INFO unit.image-builder-noble-amd64-ps6/0.juju-log server.go:325 image:385: Required relation data not yet set.
2025-04-09 14:25:17.350	
2025-04-09 12:25:17 WARNING unit.image-builder-noble-amd64-ps6/0.juju-log server.go:325 image:385: Cloud auth data not found in relation with reactive-amd64-noble-large-ps7/0
2025-04-09 14:25:17.852	
2025-04-09 12:25:17 INFO juju.worker.uniter.operation runhook.go:186 ran "image-relation-changed" hook (via hook dispatching script: dispatch)
2025-04-09 14:25:19.606	
2025-04-09 12:25:19 INFO unit.image-builder-noble-amd64-ps6/0.juju-log server.go:325 Required relation data not yet set.
2025-04-09 14:25:19.606	
2025-04-09 12:25:19 WARNING unit.image-builder-noble-amd64-ps6/0.juju-log server.go:325 Required field not yet set on reactive-amd64-noble-large-ps7/0.
2025-04-09 14:25:19.606	
2025-04-09 12:25:19 INFO unit.image-builder-noble-amd64-ps6/0.juju-log server.go:325 Required relation data not yet set.
2025-04-09 14:25:19.606	
2025-04-09 12:25:19 WARNING unit.image-builder-noble-amd64-ps6/0.juju-log server.go:325 Required field not yet set on reactive-amd64-noble-large-ps7/0.
2025-04-09 14:25:19.606	
2025-04-09 12:25:19 INFO unit.image-builder-noble-amd64-ps6/0.juju-log server.go:325 Run build command: ['/usr/bin/run-one', '/usr/bin/sudo', '--preserve-env', '/home/ubuntu/.local/bin/github-runner-image-builder', 'run', 'builder', REDACTED]
2025-04-09 15:06:06.570	
2025-04-09 13:06:06 INFO unit.image-builder-noble-amd64-ps6/0.juju-log server.go:325 Required relation data not yet set.
2025-04-09 15:06:06.570	
2025-04-09 13:06:06 WARNING unit.image-builder-noble-amd64-ps6/0.juju-log server.go:325 Cloud auth data not found in relation with reactive-amd64-noble-large-ps7/0
2025-04-09 15:06:09.579	
2025-04-09 13:06:09 INFO unit.image-builder-noble-amd64-ps6/0.juju-log server.go:325 image:385: Run build command: ['/usr/bin/run-one', '/usr/bin/sudo', '--preserve-env', '/home/ubuntu/.local/bin/github-runner-image-builder', 'run', 'builder', REDACTED]
```
### Juju Events Changes

image relation changed has been adapted according to the description above



### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `senior-review-required`, `documentation`)
- [x] The docs/changelog.md is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
