### PR TITLE
Feat: reuse image id on relation changed

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @cbartz @yhaliaw @javierdelapuente
+*       @cbartz @yhaliaw @yanksyoon

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @cbartz @yhaliaw @yanksyoon
+*       @cbartz @yhaliaw @yanksyoon @javierdelapuente

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,11 +1,11 @@
-## [#121 reuse image id on relation changed](https://github.com/canonical/github-runner-image-builder-operator/pull/121)
+## [#121 reuse image id on relation changed](https://github.com/canonical/github-runner-image-builder-operator/pull/121)(2025-05-28)
 > Reuse the already existing image in an cloud and instead of rebuilding on image relation changed.
 
 ### Performance Improvements
 * Image build propagation to newly joined units should be faster as they are not rebuilt.
 
 
-## [#113 fix: skip run if relation data is not ready](https://github.com/canonical/github-runner-image-builder-operator/pull/113)
+## [#113 fix: skip run if relation data is not ready](https://github.com/canonical/github-runner-image-builder-operator/pull/113)(2025-04-29)
 > Fix: Skip image build run if relation data is not ready
 
 ### Bug Fixes

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,3 +1,10 @@
+## [#121 reuse image id on relation changed](https://github.com/canonical/github-runner-image-builder-operator/pull/121)
+> Reuse the already existing image in an cloud and instead of rebuilding on image relation changed.
+
+### Performance Improvements
+* Image build propagation to newly joined units should be faster as they are not rebuilt.
+
+
 ## [#113 fix: skip run if relation data is not ready](https://github.com/canonical/github-runner-image-builder-operator/pull/113)
 > Fix: Skip image build run if relation data is not ready
 

--- a/src/builder.py
+++ b/src/builder.py
@@ -734,7 +734,7 @@ def _build_run_service_options(service_options: _ServiceOptions) -> list[str]:
 def get_latest_images(
     config_matrix: ConfigMatrix, static_config: StaticConfigs
 ) -> list[CloudImage]:
-    """Fetch the latest image build ID.
+    """Fetch the latest image build IDs for the clouds.
 
     Args:
         config_matrix: Matricized values of configurable image parameters.
@@ -753,7 +753,7 @@ def get_latest_images(
             get_results = pool.map(_get_latest_image, fetch_configs)
     except multiprocessing.ProcessError as exc:
         raise GetLatestImageError("Failed to run parallel fetch") from exc
-    return get_results
+    return list(filter(lambda image: image.image_id, get_results))
 
 
 @dataclasses.dataclass

--- a/src/builder.py
+++ b/src/builder.py
@@ -797,14 +797,15 @@ def _parametrize_fetch(
     """
     configs = []
     for base in config_matrix.bases:
-        configs.append(
-            FetchConfig(
-                arch=static_config.image_config.arch,
-                base=base,
-                cloud_id=static_config.cloud_config.build_cloud,
-                prefix=static_config.cloud_config.resource_prefix,
+        for cloud_id in static_config.cloud_config.upload_clouds:
+            configs.append(
+                FetchConfig(
+                    arch=static_config.image_config.arch,
+                    base=base,
+                    cloud_id=cloud_id,
+                    prefix=static_config.cloud_config.resource_prefix,
+                )
             )
-        )
     return tuple(configs)
 
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -120,7 +120,7 @@ class GithubRunnerImageBuilderCharm(ops.CharmBase):
                 evt.unit.name,
             )
 
-            self.image_observer.update_image_data(cloud_images)
+            self.image_observer.update_image_data([cloud_images])
         else:
             self._run(cloud_id=cloud_id)
         self.unit.status = ops.ActiveStatus()

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -116,21 +116,68 @@ def dispatch_time_fixture():
     return datetime.now(tz=timezone.utc)
 
 
+@pytest.fixture(scope="module", name="test_charm_file")
+def test_charm_file_fixture() -> str:
+    """Build the charm and return the path to the built charm."""
+    subprocess.check_call(  # nosec: B603
+        ["/snap/bin/charmcraft", "pack", "-p", "tests/integration/data/charm"]
+    )
+    return "./test_ubuntu-22.04-amd64.charm"
+
+
 @pytest_asyncio.fixture(scope="module", name="test_charm")
 async def test_charm_fixture(
     model: Model,
     test_id: str,
+    test_charm_file: str,
     private_endpoint_configs: PrivateEndpointConfigs,
 ) -> AsyncGenerator[Application, None]:
     """The test charm that becomes active when valid relation data is given."""
-    # The predefine inputs here can be trusted
-    subprocess.check_call(  # nosec: B603
-        ["/snap/bin/charmcraft", "pack", "-p", "tests/integration/data/charm"]
-    )
-    logger.info("Deploying built test charm.")
     app_name = f"test-{test_id}"
+    app = await _deploy_test_charm(app_name, model, private_endpoint_configs, test_charm_file)
+
+    yield app
+
+    await model.remove_application(app_name=app_name)
+    logger.info("Test charm application %s removed.", app_name)
+
+
+@pytest_asyncio.fixture(scope="module", name="test_charm_2")
+async def test_charm_2(
+    model: Model,
+    test_id: str,
+    test_charm_file: str,
+    private_endpoint_configs: PrivateEndpointConfigs,
+) -> AsyncGenerator[Application, None]:
+    """A second test charm that becomes active when valid relation data is given."""
+    app_name = f"test2-{test_id}"
+    app = await _deploy_test_charm(app_name, model, private_endpoint_configs, test_charm_file)
+
+    yield app
+
+    logger.info("Cleaning up test charm.")
+    await model.remove_application(app_name=app_name)
+    logger.info("Test charm application %s removed.", app_name)
+
+
+async def _deploy_test_charm(
+    app_name: str,
+    model: Model,
+    private_endpoint_configs: PrivateEndpointConfigs,
+    test_charm_file: str,
+):
+    """Deploy the test charm with the given application name.
+
+    Args:
+        app_name: The name of the application to deploy.
+        model: The Juju model to deploy the charm in.
+        private_endpoint_configs: The OpenStack private endpoint configurations.
+        test_charm_file: The path to the built test charm file.
+
+    """
+    logger.info("Deploying built test charm")
     app: Application = await model.deploy(
-        "./test_ubuntu-22.04-amd64.charm",
+        test_charm_file,
         app_name,
         config={
             "openstack-auth-url": private_endpoint_configs["auth_url"],
@@ -141,12 +188,7 @@ async def test_charm_fixture(
             "openstack-user-name": private_endpoint_configs["username"],
         },
     )
-
-    yield app
-
-    logger.info("Cleaning up test charm.")
-    await model.remove_application(app_name=app_name)
-    logger.info("Test charm removed.")
+    return app
 
 
 @pytest.fixture(scope="module", name="arch")

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -67,34 +67,6 @@ async def test_build_image(
     await wait_for_images(openstack_connection, dispatch_time, image_names)
 
 
-@pytest.mark.asyncio
-async def test_periodic_rebuilt(
-    app: Application,
-    app_config: dict,
-    openstack_connection: Connection,
-    image_names: list[str],
-):
-    """
-    arrange: A deployed active charm.
-    act: Modify the crontab to run every minute.
-    assert: An image is built successfully.
-    """
-    unit: Unit = next(iter(app.units))
-
-    await app.model.wait_for_idle(apps=(app.name,), status="active", timeout=30 * 60)
-
-    dispatch_time = datetime.now(tz=timezone.utc)
-    async with _change_cronjob_to_minutes(
-        unit, current_hour_interval=app_config[BUILD_INTERVAL_CONFIG_NAME]
-    ):
-
-        await wait_for_images(
-            openstack_connection=openstack_connection,
-            dispatch_time=dispatch_time,
-            image_names=image_names,
-        )
-
-
 # Ignore the "too many arguments" warning, as this is not significant for a test function where
 # the arguments are fixtures and the function is not expected to be called directly.
 async def test_charm_another_app(  # pylint: disable=R0913,R0917
@@ -150,6 +122,34 @@ async def test_charm_another_app(  # pylint: disable=R0913,R0917
             image_builder_unit_name
         ]["data"]["images"]
     )
+
+
+@pytest.mark.asyncio
+async def test_periodic_rebuilt(
+    app: Application,
+    app_config: dict,
+    openstack_connection: Connection,
+    image_names: list[str],
+):
+    """
+    arrange: A deployed active charm.
+    act: Modify the crontab to run every minute.
+    assert: An image is built successfully.
+    """
+    unit: Unit = next(iter(app.units))
+
+    await app.model.wait_for_idle(apps=(app.name,), status="active", timeout=30 * 60)
+
+    dispatch_time = datetime.now(tz=timezone.utc)
+    async with _change_cronjob_to_minutes(
+        unit, current_hour_interval=app_config[BUILD_INTERVAL_CONFIG_NAME]
+    ):
+
+        await wait_for_images(
+            openstack_connection=openstack_connection,
+            dispatch_time=dispatch_time,
+            image_names=image_names,
+        )
 
 
 @asynccontextmanager

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -126,7 +126,8 @@ async def test_charm_another_app(  # pylint: disable=R0913,R0917
             is None
         )
 
-    # Check that relation data is same for both test charms
+    # Check that images in relation data is same for both test charms
+    image_builder_unit_name = app.units[0].name
     test_charm_unit_name = test_charm.units[0].name
     _, test_charm_unit_data, _ = await ops_test.juju(
         "show-unit", test_charm_unit_name, "--format", "json"
@@ -140,8 +141,12 @@ async def test_charm_another_app(  # pylint: disable=R0913,R0917
     test_charm2_unit_data = json.loads(test_charm2_unit_data)
 
     assert (
-        test_charm_unit_data[test_charm_unit_name]["relation-info"][0]["related-units"]
-        == test_charm2_unit_data[test_charm_2_unit_name]["relation-info"][0]["related-units"]
+        test_charm_unit_data[test_charm_unit_name]["relation-info"][0]["related-units"][
+            image_builder_unit_name
+        ]["data"]["images"]
+        == test_charm2_unit_data[test_charm_2_unit_name]["relation-info"][0]["related-units"][
+            image_builder_unit_name
+        ]["data"]["images"]
     )
 
 

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -69,7 +69,7 @@ async def test_build_image(
 
 # Ignore the "too many arguments" warning, as this is not significant for a test function where
 # the arguments are fixtures and the function is not expected to be called directly.
-async def test_charm_another_app(  # pylint: disable=R0913,R0917
+async def test_charm_another_app_does_not_rebuild_image(  # pylint: disable=R0913,R0917
     app: Application,
     test_charm: Application,
     test_charm_2: Application,
@@ -84,7 +84,7 @@ async def test_charm_another_app(  # pylint: disable=R0913,R0917
     assert: No additional image is created but instead the already created ones are reused.
     """
     model: Model = app.model
-    time_now = datetime.now(tz=timezone.utc)
+    time_before_relation = datetime.now(tz=timezone.utc)
 
     await model.integrate(app.name, test_charm_2.name)
     await model.wait_for_idle(apps=(test_charm_2.name,), status="active", timeout=30 * 60)
@@ -93,7 +93,9 @@ async def test_charm_another_app(  # pylint: disable=R0913,R0917
     for image_name in image_names:
         assert (
             image_created_from_dispatch(
-                image_name=image_name, connection=openstack_connection, dispatch_time=time_now
+                image_name=image_name,
+                connection=openstack_connection,
+                dispatch_time=time_before_relation,
             )
             is None
         )

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -108,8 +108,6 @@ async def test_charm_another_app(
     assert: No additional image is created but instead the already created ones are reused.
     """
     model: Model = app.model
-    await model.integrate(app.name, test_charm.name)
-    await model.wait_for_idle([app.name], wait_for_active=True, timeout=60 * 60)
     time_now = datetime.now(tz=timezone.utc)
 
     await model.integrate(app.name, test_charm_2.name)

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -108,7 +108,7 @@ async def test_charm_another_unit(
     time_now = datetime.now(tz=timezone.utc)
     model: Model = app.model
     # TODO: deploy another app , because another unit might interfere with following tests?
-    await app.add_unit()
+    await test_charm.add_unit()
     await model.wait_for_idle(apps=[test_charm.name], status="active", timeout=30 * 60)
 
     # Check that no new image is created

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -115,7 +115,7 @@ async def test_charm_another_app(  # pylint: disable=R0913,R0917
     time_now = datetime.now(tz=timezone.utc)
 
     await model.integrate(app.name, test_charm_2.name)
-    await model.wait_for_idle(apps=[test_charm.name], status="active", timeout=30 * 60)
+    await model.wait_for_idle(apps=(test_charm_2.name,), status="active", timeout=30 * 60)
 
     # Check that no new image is created
     for image_name in image_names:
@@ -132,19 +132,21 @@ async def test_charm_another_app(  # pylint: disable=R0913,R0917
     _, test_charm_unit_data, _ = await ops_test.juju(
         "show-unit", test_charm_unit_name, "--format", "json"
     )
+    logger.info("Test charm unit data: %s", test_charm_unit_data)
     test_charm_unit_data = json.loads(test_charm_unit_data)
 
     test_charm_2_unit_name = test_charm_2.units[0].name
-    _, test_charm2_unit_data, _ = await ops_test.juju(
+    _, test_charm_2_unit_data, _ = await ops_test.juju(
         "show-unit", test_charm_2_unit_name, "--format", "json"
     )
-    test_charm2_unit_data = json.loads(test_charm2_unit_data)
+    logger.info("Test charm 2 unit data: %s", test_charm_2_unit_data)
+    test_charm_2_unit_data = json.loads(test_charm_2_unit_data)
 
     assert (
         test_charm_unit_data[test_charm_unit_name]["relation-info"][0]["related-units"][
             image_builder_unit_name
         ]["data"]["images"]
-        == test_charm2_unit_data[test_charm_2_unit_name]["relation-info"][0]["related-units"][
+        == test_charm_2_unit_data[test_charm_2_unit_name]["relation-info"][0]["related-units"][
             image_builder_unit_name
         ]["data"]["images"]
     )

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -2,10 +2,7 @@
 # See LICENSE file for licensing details.
 
 """Unit tests for charm module."""
-
-# Need access to protected functions for testing
-# pylint:disable=protected-access
-
+import secrets
 from unittest.mock import MagicMock
 
 import ops
@@ -17,6 +14,9 @@ import image
 import proxy
 import state
 from charm import GithubRunnerImageBuilderCharm
+
+# Need access to protected functions for testing
+# pylint:disable=protected-access
 
 
 @pytest.fixture(name="mock_builder")
@@ -190,7 +190,7 @@ def test__on_image_relation_changed_image_already_in_cloud(
     fake_clouds_auth_config = state.CloudsAuthConfig(
         auth_url="http://example.com",
         username="user",
-        password="pass",  # nosec no real password
+        password=secrets.token_hex(16),
         project_name="project_name",
         project_domain_name="project_domain_name",
         user_domain_name="user_domain_name",

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -200,13 +200,16 @@ def test__on_image_relation_changed_image_already_in_cloud(
         "from_unit_relation_data",
         MagicMock(return_value=fake_clouds_auth_config),
     )
-    builder.get_latest_images.return_value = [["latest"]]
+    cloud_image = builder.CloudImage(
+        arch=state.Arch.X64, base=state.BaseImage.NOBLE, cloud_id="demo_demo", image_id=""
+    )
+    builder.get_latest_images.return_value = [cloud_image]
 
     charm._on_image_relation_changed(MagicMock())
 
     assert charm.unit.status == ops.ActiveStatus()
     assert builder.run.call_count == 0
-    charm.image_observer.update_image_data.assert_called_with([["latest"]])
+    charm.image_observer.update_image_data.assert_called_with([[cloud_image]])
 
 
 @pytest.mark.usefixtures("mock_builder")


### PR DESCRIPTION
Applicable spec: n/a

### Overview

Don't run image build run on every relation changed, but instead reuse an already built image for that specific cloud.

### Rationale

We have a GitHub Runner deployment where most applications use the same cloud, which means an image is likely already present for a newly joined unit. Before this PR, every image relation changed triggered a new run, which is unnecessary, as images get rebuilt periodically anyway (default every 6 hours). We can speed up new deployments a lot by reusing the already existing image.

### Juju Events Changes

adaption to image relation changed as outlined above

### Module Changes

Mostly the `builder.py` to fix `get_latest_images` (which was broken) and `charm.py` to use this function. 

### Library Changes

n/a

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `senior-review-required`, `documentation`)
- [x] The docs/changelog.md is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
