### PR TITLE
feat: log timestamp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ clouds.yaml
 # Mac filesystem artifact
 **/.DS_Store
 **./.DS_Store
+
+# Testing artefacts
+testing_key.pem

--- a/app/src/github_runner_image_builder/logging.py
+++ b/app/src/github_runner_image_builder/logging.py
@@ -22,6 +22,8 @@ def configure(log_level: str | int) -> None:
     log_handler = logging.handlers.WatchedFileHandler(filename=LOG_FILE_PATH, encoding="utf-8")
     log_level_normalized = log_level.upper() if isinstance(log_level, str) else log_level
     log_handler.setLevel(log_level_normalized)
+    formatter = logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")
+    log_handler.setFormatter(formatter)
     logging.basicConfig(
         level=log_level_normalized,
         handlers=(log_handler,),

--- a/app/src/github_runner_image_builder/logging.py
+++ b/app/src/github_runner_image_builder/logging.py
@@ -7,7 +7,7 @@ import logging
 import logging.handlers
 import pathlib
 
-LOG_FILE_DIR = pathlib.Path.home() / "github-runner-image-builder/log"
+LOG_FILE_DIR = pathlib.Path("/var/log/github-runner-image-builder")
 LOG_FILE_PATH = LOG_FILE_DIR / "info.log"
 
 

--- a/app/tests/integration/conftest.py
+++ b/app/tests/integration/conftest.py
@@ -168,7 +168,7 @@ def ssh_key_fixture(
 ) -> typing.Generator[types.SSHKey, None, None]:
     """The openstack ssh key fixture."""
     keypair: Keypair = openstack_connection.create_keypair(f"test-image-builder-keys-{test_id}")
-    ssh_key_path = Path("tmp_key")
+    ssh_key_path = Path("testing_key.pem")
     ssh_key_path.touch(exist_ok=True)
     ssh_key_path.write_text(keypair.private_key, encoding="utf-8")
 

--- a/app/tests/unit/test_cli.py
+++ b/app/tests/unit/test_cli.py
@@ -13,8 +13,14 @@ from unittest.mock import MagicMock
 import pytest
 from click.testing import CliRunner
 
-from github_runner_image_builder import cli, config
+from github_runner_image_builder import cli, config, logging
 from github_runner_image_builder.cli import main
+
+
+@pytest.fixture(name="monkeypatch_logging_configure", autouse=True)
+def monkeypatch_logging_configure(monkeypatch):
+    """Monkeypatch log dir to be accessible when testing."""
+    monkeypatch.setattr(logging, "configure", MagicMock())
 
 
 @pytest.fixture(scope="function", name="latest_build_id_inputs")

--- a/app/tests/unit/test_logging.py
+++ b/app/tests/unit/test_logging.py
@@ -1,0 +1,51 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Unit tests for logging module."""
+import logging as logging_module
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from github_runner_image_builder import logging
+from github_runner_image_builder.logging import configure
+
+
+@pytest.fixture(autouse=True, name="patched_log_directory")
+def patched_log_directory_fixture(tmp_path, monkeypatch):
+    """Automatically patch LOG_FILE_DIR to use a temporary directory."""
+    monkeypatch.setattr(
+        logging, "LOG_FILE_DIR", (log_path := tmp_path / "github-runner-image-builder/log")
+    )
+    return log_path
+
+
+@pytest.fixture(autouse=True)
+def patched_log_path(patched_log_directory, monkeypatch):
+    """Automatically patch LOG_FILE_PATH to use a temporary directory."""
+    monkeypatch.setattr(logging, "LOG_FILE_PATH", patched_log_directory / "info.log")
+
+
+def test_configure_logging_creates_log_directory(patched_log_directory: Path):
+    """
+    arrange: none.
+    act: when logging configure is called.
+    assert: log file dir is created.
+    """
+    configure("INFO")
+
+    patched_log_directory.exists()
+
+
+def test_configure_logging_uses_formatted_logs(monkeypatch):
+    """
+    arrange: none.
+    act: when logging configure is called.
+    assert: log formatter is called with timestamped log format.
+    """
+    mock_formatter = MagicMock()
+    monkeypatch.setattr(logging_module, "Formatter", mock_formatter)
+    configure("DEBUG")
+
+    mock_formatter.assert_called_with("%(asctime)s - %(levelname)s - %(message)s")

--- a/src/charm.py
+++ b/src/charm.py
@@ -24,7 +24,7 @@ import image
 import proxy
 import state
 
-LOG_FILE_DIR = Path.home() / "github-runner-image-builder/log"
+LOG_FILE_DIR = Path("/var/log/github-runner-image-builder")
 LOG_FILE_PATH = LOG_FILE_DIR / "info.log"
 
 logger = logging.getLogger(__name__)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -440,7 +440,7 @@ def ssh_key_fixture(
     keypair: Keypair = openstack_connection.create_keypair(
         f"test-image-builder-operator-keys-{test_id}"
     )
-    ssh_key_path = Path("tmp_key")
+    ssh_key_path = Path("testing_key.pem")
     ssh_key_path.touch(exist_ok=True)
     ssh_key_path.write_text(keypair.private_key, encoding="utf-8")
 

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -188,8 +188,7 @@ async def test_log_rotated(app: Application):
     await app.model.wait_for_idle(apps=(app.name,), timeout=30 * 60)
     test_log = "this log should be rotated"
     await unit.ssh(
-        command=f"echo '{test_log}' | "
-        "sudo tee -a /root/github-runner-image-builder/log/info.log"
+        command=f"echo '{test_log}' | " "sudo tee -a /var/log/github-runner-image-builder/info.log"
     )
 
     # Test that the configuration is loaded successfully using --debug flag
@@ -197,10 +196,9 @@ async def test_log_rotated(app: Application):
         command="sudo /usr/sbin/logrotate /etc/logrotate.conf --debug 2>&1"
     )
     assert (
-        "rotating pattern: /root/github-runner-image-builder/log/info.log"
-        in logrotate_debug_output
+        "rotating pattern: /var/log/github-runner-image-builder/info.log" in logrotate_debug_output
     )
     # Manually trigger logrotate using --force flag
     await unit.ssh(command="sudo /usr/sbin/logrotate /etc/logrotate.conf --force")
-    log_output = await unit.ssh(command="sudo cat /root/github-runner-image-builder/log/info.log")
+    log_output = await unit.ssh(command="sudo cat /var/log/github-runner-image-builder/info.log")
     assert test_log not in log_output


### PR DESCRIPTION
Applicable spec: N/A

### Overview

<!-- A high level overview of the change -->
- Adds timestamp to logging
- Changes log directory to /var/log/github-runner-image-builder/ for cos_agent to scrape
- Added testing artefacts to .gitignore

### Rationale

- Timestamp being invisible leads to harder debugging.

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `senior-review-required`, `documentation`)
- [ ] The docs/changelog.md is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
No user relevant changes.