### PR TITLE
fix: click case insensitive

### DIFF
--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -1,4 +1,4 @@
-click==8.1.8
+click==8.2.1
 fabric==3.2.2
 Jinja2==3.1.6
 openstacksdk==4.5.0

--- a/app/src/github_runner_image_builder/cli.py
+++ b/app/src/github_runner_image_builder/cli.py
@@ -59,9 +59,7 @@ def main(ctx: click.Context, log_level: str | int, os_cloud: str) -> None:
 @main.command(name="init")
 @click.option(
     "--arch",
-    type=click.Choice(
-        (config.Arch.ARM64, config.Arch.X64, config.Arch.S390X, config.Arch.PPC64LE)
-    ),
+    type=click.Choice(config.Arch, case_sensitive=False),
     help="Image architecture to initialize for.",
     required=True,
 )
@@ -139,9 +137,7 @@ def _parse_url(
 @click.argument("image_name")
 @click.option(
     "--arch",
-    type=click.Choice(
-        (config.Arch.ARM64, config.Arch.X64, config.Arch.S390X, config.Arch.PPC64LE)
-    ),
+    type=click.Choice(config.Arch, case_sensitive=False),
     help="Image architecture.",
     required=True,
 )

--- a/app/tests/unit/test_cli.py
+++ b/app/tests/unit/test_cli.py
@@ -223,7 +223,7 @@ def test_run(
         command,
     )
 
-    assert result.exit_code == 0
+    assert result.exit_code == 0, f"Unexpected exit code {result.exit_code}, {result.output}"
 
 
 def test__load_secrets():


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->
- Fixes case sensitivity for click. This is blocking: https://github.com/canonical/github-runner-image-builder-operator/pull/117

### Rationale

- Blocking click updates / renovate updates.

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `senior-review-required`, `documentation`)
- [ ] The docs/changelog.md is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
No user facing changes (backwards compatible)