### PR TITLE
test: cleanup test images

### DIFF
--- a/app/tests/integration/conftest.py
+++ b/app/tests/integration/conftest.py
@@ -144,9 +144,17 @@ def cloud_name_fixture(clouds_yaml_contents: str) -> str:
 
 
 @pytest.fixture(scope="module", name="openstack_connection")
-def openstack_connection_fixture(cloud_name: str) -> Connection:
+def openstack_connection_fixture(
+    cloud_name: str, test_id: str
+) -> typing.Generator[Connection, None, None]:
     """The openstack connection instance."""
-    return openstack.connect(cloud_name)
+    with openstack.connect(cloud_name) as conn:
+        yield conn
+
+        images = conn.list_images()
+        for image in images:
+            if str(image.name).startswith(test_id):
+                conn.delete_image(image)
 
 
 @pytest.fixture(scope="module", name="dockerhub_mirror")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -286,7 +286,7 @@ def openstack_connection_fixture(
     clouds_yaml = yaml.safe_load(clouds_yaml_contents)
     clouds_yaml_path = Path.cwd() / "clouds.yaml"
     clouds_yaml_path.write_text(data=clouds_yaml_contents, encoding="utf-8")
-    first_cloud = next(iter(clouds_yaml["clouds"].keys()))
+    first_cloud = list(clouds_yaml["clouds"].keys())[0]
     with openstack.connect(first_cloud) as conn:
         yield conn
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -297,7 +297,8 @@ def cleanup_resources_fixture(
     yield
 
     for image_name in image_names:
-        openstack_connection.delete_image(image_name)
+        for image in openstack_connection.search_images(name_or_id=image_name):
+            openstack_connection.delete_image(image.id)
 
 
 @pytest.fixture(scope="module", name="test_id")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -279,9 +279,7 @@ def clouds_yaml_fixture(
 
 
 @pytest.fixture(scope="module", name="openstack_connection")
-def openstack_connection_fixture(
-    clouds_yaml_contents: str, image_names: list[str]
-) -> Generator[Connection, None, None]:
+def openstack_connection_fixture(clouds_yaml_contents: str) -> Generator[Connection, None, None]:
     """The openstack connection instance."""
     clouds_yaml = yaml.safe_load(clouds_yaml_contents)
     clouds_yaml_path = Path.cwd() / "clouds.yaml"
@@ -290,8 +288,16 @@ def openstack_connection_fixture(
     with openstack.connect(first_cloud) as conn:
         yield conn
 
-        for image_name in image_names:
-            conn.delete_image(image_name)
+
+@pytest.fixture(scope="module", name="clean_up_resources", autouse=True)
+def cleanup_resources_fixture(
+    openstack_connection: Connection, image_names: list[str]
+) -> Generator[None, None, None]:
+    """Clean up resources after the tests are complete."""
+    yield
+
+    for image_name in image_names:
+        openstack_connection.delete_image(image_name)
 
 
 @pytest.fixture(scope="module", name="test_id")

--- a/tox.ini
+++ b/tox.ini
@@ -66,7 +66,7 @@ commands =
       --skip {toxinidir}/build --skip {toxinidir}/lib --skip {toxinidir}/venv \
       --skip {toxinidir}/.mypy_cache --skip {toxinidir}/icon.svg
     # pflake8 wrapper supports config from pyproject.toml
-    pflake8 {[vars]all_path} --ignore=W503
+    pflake8 {[vars]src_path} --ignore=W503
     isort --check-only --diff {[vars]all_path}
     black --check --diff {[vars]all_path}
     mypy {[vars]all_path}


### PR DESCRIPTION
Applicable spec: <link>

### Overview

- Cleanup test images after a single module test
<!-- A high level overview of the change -->

### Rationale

- The image is piling up on the test environment
<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `senior-review-required`, `documentation`)
- [ ] The docs/changelog.md is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

No user relevant changes
<!-- Explanation for any unchecked items above -->
