### PR TITLE
chore: use canonical built runner binaries

### DIFF
--- a/app/src/github_runner_image_builder/config.py
+++ b/app/src/github_runner_image_builder/config.py
@@ -131,7 +131,6 @@ LOG_LEVELS = tuple(
 )
 
 FORK_RUNNER_BINARY_REPO = "canonical/github-actions-runner"
-UPSTREAM_RUNNER_BINARY_REPO = "actions/runner"
 
 
 @dataclasses.dataclass

--- a/app/src/github_runner_image_builder/openstack_builder.py
+++ b/app/src/github_runner_image_builder/openstack_builder.py
@@ -517,16 +517,13 @@ def _generate_cloud_init_script(
     apt_packages = IMAGE_DEFAULT_APT_PACKAGES
     if image_config.arch in (Arch.S390X, Arch.PPC64LE):
         apt_packages = IMAGE_DEFAULT_APT_PACKAGES + S390X_PPC64LE_ADDITIONAL_APT_PACKAGES
-        runner_binary_repo = FORK_RUNNER_BINARY_REPO
-    else:
-        runner_binary_repo = UPSTREAM_RUNNER_BINARY_REPO
     return template.render(
         PROXY_URL=proxy,
         APT_PACKAGES=" ".join(apt_packages),
         HWE_VERSION=BaseImage.get_version(image_config.base),
         RUNNER_VERSION=image_config.runner_version,
         RUNNER_ARCH=image_config.arch.value,
-        RUNNER_BINARY_REPO=runner_binary_repo,
+        RUNNER_BINARY_REPO=FORK_RUNNER_BINARY_REPO,
     )
 
 


### PR DESCRIPTION
Applicable spec: <link>

### Overview

- Switch the upstream runner binary source to use Canonical's binaries
<!-- A high level overview of the change -->

### Rationale

- Support for automated patching of S390x, PPC64EL as well as ARM64 and AMD64 has landed. We are now able to fully use GitHub runners built from source within Canonical's trust boundaries.
<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `senior-review-required`, `documentation`)
- [x] The docs/changelog.md is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
