### PR TITLE
chore: unpin flake8 dependencies

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -37,18 +37,18 @@ description = Check code against coding style standards
 deps =
     black
     codespell
-    flake8<6.0.0
+    flake8
     flake8-builtins
-    flake8-copyright<6.0.0
-    flake8-docstrings>=1.6.0
-    flake8-docstrings-complete>=1.0.3
-    flake8-test-docs>=1.0
+    flake8-copyright
+    flake8-docstrings
+    flake8-docstrings-complete
+    flake8-test-docs
     isort
     mypy
     pep8-naming
     pydocstyle>=2.10
     pylint
-    pyproject-flake8<6.0.0
+    pyproject-flake8
     pytest
     pytest-asyncio
     pytest-operator
@@ -77,12 +77,12 @@ description = Check plugins code against coding style standards
 deps =
     black
     codespell
-    flake8<6.0.0
+    flake8
     flake8-builtins
-    flake8-copyright<6.0.0
-    flake8-docstrings>=1.6.0
-    flake8-docstrings-complete>=1.0.3
-    flake8-test-docs>=1.0
+    flake8-copyright
+    flake8-docstrings
+    flake8-docstrings-complete
+    flake8-test-docs
     indico==3.2
     isort
     mypy
@@ -91,7 +91,7 @@ deps =
     indico_rock/plugins/anonymize
     pydocstyle>=2.10
     pylint
-    pyproject-flake8<6.0.0
+    pyproject-flake8
     pytest
     pytest-asyncio
     pytest-operator


### PR DESCRIPTION
Applicable spec: <link>

### Overview

- Unpin flake8 plugin dependency versions
<!-- A high level overview of the change -->

### Rationale

- To update the flake8 plugins which should then be compatible with Python 3.12 on noble runners.
<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [ ] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

No user relevant changes

<!-- Explanation for any unchecked items above -->
