### PR TITLE
docs: add resource recommendation for charm deployment

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -3,6 +3,9 @@ name: Tests
 on:
   pull_request:
 
+permissions:
+  pull-requests: write
+
 jobs:
   unit-tests:
     uses: canonical/operator-workflows/.github/workflows/test.yaml@main

--- a/.vale/styles/config/vocabularies/local/accept.txt
+++ b/.vale/styles/config/vocabularies/local/accept.txt
@@ -3,3 +3,4 @@ chroot
 cron
 opentelemetry
 pipx
+vCPUs

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ flavors for the builder VM.
 
 Recommended builder VM resources:
 
+<!-- vale Canonical.013-Spell-out-numbers-below-10 = NO -->
 - 2 vCPUs
 - 8 GiB RAM
 - 20 GiB disk
@@ -42,6 +43,7 @@ Minimum accepted builder VM resources:
 - 2 vCPUs
 - 1 GiB RAM
 - 20 GiB disk
+<!-- vale Canonical.013-Spell-out-numbers-below-10 = YES -->
 
 Using the recommended resources helps avoid failures during image build and initialization.
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,21 @@ Deploy GitHub runner image builder with GitHub runners.
 <!--Indicate software and hardware prerequisites-->
 
 You'll need a working [OpenStack installation](https://microstack.run/docs/single-node) with
-flavors with a minimum of 2 CPU cores, 8GB RAM and 10GB disk.
+flavors for the builder VM.
+
+Recommended builder VM resources:
+
+- 2 vCPUs
+- 8 GiB RAM
+- 20 GiB disk
+
+Minimum accepted builder VM resources:
+
+- 2 vCPUs
+- 1 GiB RAM
+- 20 GiB disk
+
+Using the recommended resources helps avoid failures during image build and initialization.
 
 ### Set up
 

--- a/app/doc/tutorial/quick-start.md
+++ b/app/doc/tutorial/quick-start.md
@@ -16,8 +16,7 @@
 
 ### Recommended resources for deployment
 
-For reliable image builds, ensure your OpenStack environment has a flavor for build VMs
-with at least:
+For reliable image builds, use a recommended flavor for build VMs with:
 
 - 2 vCPUs
 - 8 GiB RAM

--- a/app/doc/tutorial/quick-start.md
+++ b/app/doc/tutorial/quick-start.md
@@ -14,6 +14,18 @@
 - Working [OpenStack environment](https://microstack.run/docs/single-node)
 - A `clouds.yaml` configuration with the OpenStack environment
 
+### Recommended resources for deployment
+
+For reliable image builds, ensure your OpenStack environment has a flavor for build VMs
+with at least:
+
+- 2 vCPUs
+- 8 GiB RAM
+- 20 GiB disk
+
+The CLI can work with lower memory if a smaller flavor is selected, but using the
+recommended flavor significantly reduces build failures.
+
 ## Steps
 
 ### Install the CLI

--- a/app/doc/tutorial/quick-start.md
+++ b/app/doc/tutorial/quick-start.md
@@ -16,7 +16,7 @@
 
 ### Recommended resources for deployment
 
-For reliable image builds, use a recommended flavor for build VMs with:
+For reliable image builds, use the following recommended flavor for build VMs:
 
 - 2 vCPUs
 - 8 GiB RAM

--- a/app/pyproject.toml
+++ b/app/pyproject.toml
@@ -3,7 +3,7 @@
 
 [project]
 name = "github-runner-image-builder"
-version = "0.13.0"
+version = "0.14.0"
 authors = [
     { name = "Canonical IS DevOps", email = "is-devops-team@canonical.com" },
 ]

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,7 +2,9 @@
 
 ## [#221 Add resource recommendation for charm deployment](https://github.com/canonical/github-runner-image-builder-operator/pull/221)
 
+<!-- vale Canonical.013-Spell-out-numbers-below-10 = NO -->
 - Add 2 vCPUs, 8 GiB RAM, and 20 GiB disk OpenStack flavor recommendation.
+<!-- vale Canonical.013-Spell-out-numbers-below-10 = YES -->
 
 ## [#219 Use Juju secrets](https://github.com/canonical/github-runner-image-builder-operator/pull/219) (2026-04-17)
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,9 @@
 <!-- vale Canonical.007-Headings-sentence-case = NO -->
 
+## [#221 Add resource recommendation for charm deployment](https://github.com/canonical/github-runner-image-builder-operator/pull/221)
+
+- Add 2 vCPUs, 8 GiB RAM, and 20 GiB disk OpenStack flavor recommendation.
+
 ## [#219 Use Juju secrets](https://github.com/canonical/github-runner-image-builder-operator/pull/219) (2026-04-17)
 
 - Require `openstack-password-secret` configuration option to securely store OpenStack passwords using Juju secrets.

--- a/docs/tutorial/quick-start.md
+++ b/docs/tutorial/quick-start.md
@@ -9,7 +9,7 @@ This quick start guide will help you deploy the GitHub Runner Image Builder char
 
 ## Requirements
 
-- A working station, e.g., a laptop, with amd64 architecture.
+- A working station, for example, a laptop, with amd64 architecture.
 - Juju 3 installed and bootstrapped to a LXD controller. You can accomplish this process by
   using a Multipass VM as outlined in this guide:
   [Set up your test environment](https://documentation.ubuntu.com/juju/3.6/howto/manage-your-juju-deployment/set-up-your-juju-deployment-local-testing-and-development/)
@@ -20,11 +20,13 @@ This quick start guide will help you deploy the GitHub Runner Image Builder char
 For stable builds and fewer deployment failures, use a dedicated OpenStack flavor for
 the builder VM with:
 
+<!-- vale Canonical.013-Spell-out-numbers-below-10 = NO -->
 - 2 vCPUs
 - 8 GiB RAM
 - 20 GiB disk
 
 The charm itself enforces a lower minimum flavor (2 vCPUs, 1 GiB RAM, 20 GiB disk).
+<!-- vale Canonical.013-Spell-out-numbers-below-10 = YES -->
 
 If possible, set the `build-flavor` config to a flavor that meets the recommendation.
 

--- a/docs/tutorial/quick-start.md
+++ b/docs/tutorial/quick-start.md
@@ -15,6 +15,19 @@ This quick start guide will help you deploy the GitHub Runner Image Builder char
   [Set up your test environment](https://documentation.ubuntu.com/juju/3.6/howto/manage-your-juju-deployment/set-up-your-juju-deployment-local-testing-and-development/)
 - A running instance of [OpenStack](https://microstack.run/docs/single-node).
 
+### Recommended resources for deployment
+
+For stable builds and fewer deployment failures, use a dedicated OpenStack flavor for
+the builder VM with:
+
+- 2 vCPUs
+- 8 GiB RAM
+- 20 GiB disk
+
+The charm itself enforces a lower minimum flavor (2 vCPUs, 1 GiB RAM, 20 GiB disk).
+
+If possible, set the `build-flavor` config to a flavor that meets the recommendation.
+
 ## Steps
 
 ### Shell into the Multipass VM


### PR DESCRIPTION
Applicable spec: <link>

### Overview

Add the following recommendation for openstack flavor:
- 2 vCPUs
- 8 GiB RAM
- 20 GiB disk

which is the superset of the requirements stated in the [code](https://github.com/canonical/github-runner-image-builder-operator/blob/0cb9743868ee19a7a1bb7c245e55f3e16c5a81be/app/src/github_runner_image_builder/openstack_builder.py#L77):

> MIN_CPU = 2
> MIN_RAM = 1024  # M
> MIN_DISK = 20  # G

and existing [README guidance](https://github.com/canonical/github-runner-image-builder-operator/blob/0cb9743868ee19a7a1bb7c245e55f3e16c5a81be/README.md?plain=1#L32):

> You'll need a working [OpenStack installation](https://microstack.run/docs/single-node) with
flavors with a minimum of 2 CPU cores, 8GB RAM and 10GB disk.

### Rationale

So that user knows the recommended resource for deploying image builder and doesn't run into issues.

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `senior-review-required`, `documentation`)
- [x] The docs/changelog.md is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)
- [x] The application version is incremented in `app/pyproject.toml`

<!-- Explanation for any unchecked items above -->
