### PR TITLE
Add PPA for dotnet backport during image building

### DIFF
--- a/app/pyproject.toml
+++ b/app/pyproject.toml
@@ -3,7 +3,7 @@
 
 [project]
 name = "github-runner-image-builder"
-version = "0.13.0"
+version = "0.14.0"
 authors = [
     { name = "Canonical IS DevOps", email = "is-devops-team@canonical.com" },
 ]

--- a/app/src/github_runner_image_builder/templates/cloud-init.sh.j2
+++ b/app/src/github_runner_image_builder/templates/cloud-init.sh.j2
@@ -65,7 +65,7 @@ function install_apt_packages() {
         chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg
         echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" > /etc/apt/sources.list.d/github-cli.list
     fi
-    
+
     echo "Adding dotnet backports PPA"
     DEBIAN_FRONTEND=noninteractive /usr/bin/add-apt-repository -y ppa:dotnet/backports
     echo "Updating apt packages"

--- a/app/src/github_runner_image_builder/templates/cloud-init.sh.j2
+++ b/app/src/github_runner_image_builder/templates/cloud-init.sh.j2
@@ -66,8 +66,10 @@ function install_apt_packages() {
         echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" > /etc/apt/sources.list.d/github-cli.list
     fi
 
-    echo "Adding dotnet backports PPA"
-    DEBIAN_FRONTEND=noninteractive /usr/bin/add-apt-repository -y ppa:dotnet/backports
+    if [ $RELEASE == "resolute" ]; then
+        echo "Adding dotnet backports PPA"
+        DEBIAN_FRONTEND=noninteractive /usr/bin/add-apt-repository -y ppa:dotnet/backports
+    fi
     echo "Updating apt packages"
     DEBIAN_FRONTEND=noninteractive /usr/bin/apt-get update -y
     echo "Upgrading apt packages"

--- a/app/src/github_runner_image_builder/templates/cloud-init.sh.j2
+++ b/app/src/github_runner_image_builder/templates/cloud-init.sh.j2
@@ -65,7 +65,9 @@ function install_apt_packages() {
         chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg
         echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" > /etc/apt/sources.list.d/github-cli.list
     fi
-
+    
+    echo "Adding dotnet backports PPA"
+    DEBIAN_FRONTEND=noninteractive /usr/bin/add-apt-repository -y ppa:dotnet/backports
     echo "Updating apt packages"
     DEBIAN_FRONTEND=noninteractive /usr/bin/apt-get update -y
     echo "Upgrading apt packages"

--- a/app/tests/unit/test_openstack_builder.py
+++ b/app/tests/unit/test_openstack_builder.py
@@ -777,8 +777,10 @@ signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.co
 main" > /etc/apt/sources.list.d/github-cli.list
     fi
 
-    echo "Adding dotnet backports PPA"
-    DEBIAN_FRONTEND=noninteractive /usr/bin/add-apt-repository -y ppa:dotnet/backports
+    if [ $RELEASE == "resolute" ]; then
+        echo "Adding dotnet backports PPA"
+        DEBIAN_FRONTEND=noninteractive /usr/bin/add-apt-repository -y ppa:dotnet/backports
+    fi
     echo "Updating apt packages"
     DEBIAN_FRONTEND=noninteractive /usr/bin/apt-get update -y
     echo "Upgrading apt packages"

--- a/app/tests/unit/test_openstack_builder.py
+++ b/app/tests/unit/test_openstack_builder.py
@@ -777,6 +777,8 @@ signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.co
 main" > /etc/apt/sources.list.d/github-cli.list
     fi
 
+    echo "Adding dotnet backports PPA"
+    DEBIAN_FRONTEND=noninteractive /usr/bin/add-apt-repository -y ppa:dotnet/backports
     echo "Updating apt packages"
     DEBIAN_FRONTEND=noninteractive /usr/bin/apt-get update -y
     echo "Upgrading apt packages"

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,8 +1,8 @@
 <!-- vale Canonical.007-Headings-sentence-case = NO -->
 
-## [#222 Add PPA for dotnet backport during image building](https://github.com/canonical/github-runner-image-builder-operator/pull/222) (2026-05-22)
+## [#222 Add PPA for .NET backport during image building](https://github.com/canonical/github-runner-image-builder-operator/pull/222) (2026-05-22)
 
-- Add dotnet PPA in image building. This allows wider range of dotnet version to be installed.
+- Add .NET PPA in image building. This allows wider range of .NET version to be installed.
 
 ## [#219 Use Juju secrets](https://github.com/canonical/github-runner-image-builder-operator/pull/219) (2026-04-17)
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,9 @@
 <!-- vale Canonical.007-Headings-sentence-case = NO -->
 
+## [#222 Add PPA for dotnet backport during image building](https://github.com/canonical/github-runner-image-builder-operator/pull/222) (2026-05-22)
+
+- Add dotnet PPA in image building. This allows wider range of dotnet version to be installed.
+
 ## [#219 Use Juju secrets](https://github.com/canonical/github-runner-image-builder-operator/pull/219) (2026-04-17)
 
 - Require `openstack-password-secret` configuration option to securely store OpenStack passwords using Juju secrets.

--- a/lib/charms/grafana_agent/v0/cos_agent.py
+++ b/lib/charms/grafana_agent/v0/cos_agent.py
@@ -211,7 +211,9 @@ class GrafanaAgentMachineCharm(GrafanaAgentCharm)
 ```
 """
 
+import copy
 import enum
+import hashlib
 import json
 import logging
 import socket
@@ -254,7 +256,7 @@ if TYPE_CHECKING:
 
 LIBID = "dc15fa84cef84ce58155fb84f6c6213a"
 LIBAPI = 0
-LIBPATCH = 24
+LIBPATCH = 25
 
 PYDEPS = ["cosl >= 0.0.50", "pydantic"]
 
@@ -306,6 +308,13 @@ def _dedupe_list(items: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
         if item not in unique_items:
             unique_items.append(item)
     return unique_items
+
+
+def _dict_hash_except_key(scrape_config: Dict[str, Any], key: Optional[str]):
+    """Get a hash of the scrape_config dict, except for the specified key."""
+    cfg_for_hash = {k: v for k, v in scrape_config.items() if k != key}
+    serialized = json.dumps(cfg_for_hash, sort_keys=True)
+    return hashlib.blake2b(serialized.encode(), digest_size=4).hexdigest()
 
 
 class TracingError(Exception):
@@ -697,6 +706,27 @@ class COSAgentProvider(Object):
                 ) as e:
                     logger.error("Invalid relation data provided: %s", e)
 
+    def _deterministic_scrape_configs(
+        self, scrape_configs: List[Dict[str, Any]]
+    ) -> List[Dict[str, Any]]:
+        """Get deterministic scrape_configs with stable job names.
+
+        For stability across serializations, compute a short per-config hash
+        and append it to the existing job name (or 'default'). Keep the app
+        name as a prefix: <app>_<job_or_default>_<8hex-hash>.
+
+        Hash the whole scrape_config (except any existing job_name) so the
+        suffix is sensitive to all stable fields. Use deterministic JSON
+        serialization.
+        """
+        local_scrape_configs = copy.deepcopy(scrape_configs)
+        for scrape_config in local_scrape_configs:
+            name = scrape_config.get("job_name", "default")
+            short_id = _dict_hash_except_key(scrape_config, "job_name")
+            scrape_config["job_name"] = f"{self._charm.app.name}_{name}_{short_id}"
+
+        return sorted(local_scrape_configs, key=lambda c: c.get("job_name", ""))
+
     @property
     def _scrape_jobs(self) -> List[Dict]:
         """Return a list of scrape_configs.
@@ -711,22 +741,17 @@ class COSAgentProvider(Object):
             scrape_configs = self._scrape_configs.copy()
 
         # Convert "metrics_endpoints" to standard scrape_configs, and add them in
-        unit_name = self._charm.unit.name.replace("/", "_")
         for endpoint in self._metrics_endpoints:
-            port = endpoint["port"]
-            path = endpoint["path"]
-            sanitized_path = path.strip("/").replace("/", "_")
             scrape_configs.append(
                 {
-                    "job_name": f"{unit_name}_localhost_{port}_{sanitized_path}",
-                    "metrics_path": path,
-                    "static_configs": [{"targets": [f"localhost:{port}"]}],
+                    "metrics_path": endpoint["path"],
+                    "static_configs": [{"targets": [f"localhost:{endpoint['port']}"]}],
                 }
             )
 
         scrape_configs = scrape_configs or []
 
-        return scrape_configs
+        return self._deterministic_scrape_configs(scrape_configs)
 
     @property
     def _metrics_alert_rules(self) -> Dict:
@@ -742,7 +767,7 @@ class COSAgentProvider(Object):
         )
         alert_rules.add_path(self._metrics_rules, recursive=self._recursive)
         alert_rules.add(
-            generic_alert_groups.application_rules,
+            copy.deepcopy(generic_alert_groups.application_rules),
             group_name_prefix=JujuTopology.from_charm(self._charm).identifier,
         )
 


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->
Add the PPA for dotnet backports.

### Rationale

<!-- The reason the change is needed -->
Needed to install additional dotnet version for different ubuntu base.
E.g., jammy with dotnet 10, resolute with dotnet 8. 

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `senior-review-required`, `documentation`)
- [x] The docs/changelog.md is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)
- [x] The application version is incremented in `app/pyproject.toml`

<!-- Explanation for any unchecked items above -->
