### PR TITLE
fix: add runner user alias for GARM image compatibility (ISD-5726)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -22,7 +22,7 @@ Applicable spec: <link>
 
 ### Checklist
 
-- [ ] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
+- [ ] The [charm style guide](https://documentation.ubuntu.com/juju/3.6/reference/charm) was applied
 - [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
 - [ ] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
 - [ ] The documentation for charmhub is updated.

--- a/.github/workflows/integration_test_app.yaml
+++ b/.github/workflows/integration_test_app.yaml
@@ -14,10 +14,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image: [noble]
-        arch: [arm64]
-        # image: [focal, jammy, noble, resolute]
-        # arch: [amd64, arm64, s390x, ppc64le]
+        image: [focal, jammy, noble, resolute]
+        arch: [amd64, arm64, s390x, ppc64le]
         exclude:
           - image: focal
             arch: ppc64le
@@ -40,7 +38,7 @@ jobs:
       - uses: canonical/setup-lxd@v0.1.3
       - uses: actions/setup-python@v6
         with:
-          python-version: '3.14'
+          python-version: "3.14"
       - name: Install tox
         run: |
           sudo apt-get update

--- a/.github/workflows/integration_test_app.yaml
+++ b/.github/workflows/integration_test_app.yaml
@@ -14,8 +14,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image: [focal, jammy, noble, resolute]
-        arch: [amd64, arm64, s390x, ppc64le]
+        image: [noble]
+        arch: [arm64]
+        # image: [focal, jammy, noble, resolute]
+        # arch: [amd64, arm64, s390x, ppc64le]
         exclude:
           - image: focal
             arch: ppc64le

--- a/.github/workflows/integration_test_app.yaml
+++ b/.github/workflows/integration_test_app.yaml
@@ -14,10 +14,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image: [noble]
-        arch: [arm64]
-        # image: [focal, jammy, noble, resolute]
-        # arch: [amd64, arm64, s390x, ppc64le]
+        image: [focal, jammy, noble, resolute]
+        arch: [amd64, arm64, s390x, ppc64le]
         exclude:
           - image: focal
             arch: ppc64le

--- a/app/pyproject.toml
+++ b/app/pyproject.toml
@@ -3,7 +3,7 @@
 
 [project]
 name = "github-runner-image-builder"
-version = "0.14.0"
+version = "0.14.1"
 authors = [
     { name = "Canonical IS DevOps", email = "is-devops-team@canonical.com" },
 ]

--- a/app/src/github_runner_image_builder/openstack_builder.py
+++ b/app/src/github_runner_image_builder/openstack_builder.py
@@ -346,7 +346,7 @@ def run(
             )
         logger.info("Cleaning cloud-init state before snapshot.")
         ssh_conn.run(
-            "sudo cloud-init clean --logs --machine-id --seed",
+            "sudo cloud-init clean --logs --machine-id --seed --configs all",
             timeout=EXTERNAL_SCRIPT_GENERAL_TIMEOUT,
         )
         _shutoff_server(conn=conn, server=builder)

--- a/app/src/github_runner_image_builder/openstack_builder.py
+++ b/app/src/github_runner_image_builder/openstack_builder.py
@@ -344,6 +344,7 @@ def run(
                 script_secrets=image_config.script_config.script_secrets,
                 ssh_conn=ssh_conn,
             )
+        # Cleaning is needed to be compatible with GARM
         logger.info("Cleaning cloud-init state before snapshot.")
         ssh_conn.run(
             "sudo cloud-init clean --logs --machine-id --seed --configs all",

--- a/app/src/github_runner_image_builder/openstack_builder.py
+++ b/app/src/github_runner_image_builder/openstack_builder.py
@@ -345,7 +345,10 @@ def run(
                 ssh_conn=ssh_conn,
             )
         logger.info("Cleaning cloud-init state before snapshot.")
-        ssh_conn.run("sudo cloud-init clean", timeout=EXTERNAL_SCRIPT_GENERAL_TIMEOUT)
+        ssh_conn.run(
+            "sudo cloud-init clean --logs --machine-id --seed",
+            timeout=EXTERNAL_SCRIPT_GENERAL_TIMEOUT,
+        )
         _shutoff_server(conn=conn, server=builder)
         image = store.create_snapshot(
             cloud_name=cloud_config.cloud_name,

--- a/app/src/github_runner_image_builder/openstack_builder.py
+++ b/app/src/github_runner_image_builder/openstack_builder.py
@@ -344,6 +344,8 @@ def run(
                 script_secrets=image_config.script_config.script_secrets,
                 ssh_conn=ssh_conn,
             )
+        logger.info("Cleaning cloud-init state before snapshot.")
+        ssh_conn.run("sudo cloud-init clean", timeout=EXTERNAL_SCRIPT_GENERAL_TIMEOUT)
         _shutoff_server(conn=conn, server=builder)
         image = store.create_snapshot(
             cloud_name=cloud_config.cloud_name,

--- a/app/src/github_runner_image_builder/templates/cloud-init.sh.j2
+++ b/app/src/github_runner_image_builder/templates/cloud-init.sh.j2
@@ -175,15 +175,24 @@ function configure_system_users() {
     # --non-unique: allow reusing ubuntu's UID (duplicate UIDs are rejected by default).
     # --uid/--gid: share ubuntu's UID/GID so both users have identical file permissions.
     # --no-create-home: skip creating /home/runner; runner's home is set to /home/ubuntu instead.
-    # 2>/dev/null || true: ignore errors (e.g. runner user already exists) without failing the script.
-    /usr/sbin/useradd --non-unique --uid "$UBUNTU_UID" --gid "$UBUNTU_GID" --no-create-home --home-dir /home/ubuntu runner 2>/dev/null || true
-    /usr/sbin/usermod --append --groups docker,microk8s,lxd,sudo runner 2>/dev/null || true
+    if /usr/bin/id -u runner >/dev/null 2>&1; then
+        echo "runner user already exists; ensuring UID/GID/home match ubuntu"
+        /usr/sbin/usermod --non-unique --uid "$UBUNTU_UID" --gid "$UBUNTU_GID" --home /home/ubuntu runner
+    else
+        /usr/sbin/useradd --non-unique --uid "$UBUNTU_UID" --gid "$UBUNTU_GID" --no-create-home --home-dir /home/ubuntu runner
+    fi
+    /usr/sbin/usermod --append --groups docker,microk8s,lxd,sudo runner
     # Symlink /home/runner -> /home/ubuntu so GARM's hardcoded /home/runner/actions-runner path resolves correctly.
-    # If /home/runner exists as a plain directory (not a symlink), remove it first; otherwise ln -sfnT would
-    # create the symlink inside the directory instead of replacing it.
-    # -T: treat destination as a file path, never as a directory target (prevents ln from creating the
-    #     symlink inside /home/runner if it exists as a directory after rmdir fails).
-    [ -d /home/runner ] && ! [ -L /home/runner ] && rmdir /home/runner 2>/dev/null || true
+    # If /home/runner exists as a plain directory (not a symlink), remove it first; otherwise ln -sfnT cannot
+    # replace it. A non-empty directory is an unexpected state, so fail with a clear error instead of letting
+    # ln fail later with a less specific message.
+    # -T: treat destination as a file path, never as a directory target.
+    if [ -d /home/runner ] && ! [ -L /home/runner ]; then
+        if ! rmdir /home/runner 2>/dev/null; then
+            echo "ERROR: /home/runner exists and is not empty; cannot replace it with a symlink to /home/ubuntu" >&2
+            return 1
+        fi
+    fi
     /usr/bin/ln -sfnT /home/ubuntu /home/runner
 }
 

--- a/app/src/github_runner_image_builder/templates/cloud-init.sh.j2
+++ b/app/src/github_runner_image_builder/templates/cloud-init.sh.j2
@@ -172,11 +172,14 @@ function configure_system_users() {
     echo "Configuring runner user alias for GARM compatibility"
     UBUNTU_UID=$(/usr/bin/id -u ubuntu)
     UBUNTU_GID=$(/usr/bin/id -g ubuntu)
+    # --non-unique: allow reusing ubuntu's UID (duplicate UIDs are rejected by default).
     # --uid/--gid: share ubuntu's UID/GID so both users have identical file permissions.
     # --no-create-home: skip creating /home/runner; runner's home is set to /home/ubuntu instead.
     # 2>/dev/null || true: ignore errors (e.g. runner user already exists) without failing the script.
-    /usr/sbin/useradd --uid "$UBUNTU_UID" --gid "$UBUNTU_GID" --no-create-home --home-dir /home/ubuntu runner 2>/dev/null || true
+    /usr/sbin/useradd --non-unique --uid "$UBUNTU_UID" --gid "$UBUNTU_GID" --no-create-home --home-dir /home/ubuntu runner 2>/dev/null || true
     /usr/sbin/usermod --append --groups docker,microk8s,lxd,sudo runner 2>/dev/null || true
+    # Symlink /home/runner -> /home/ubuntu so GARM's hardcoded /home/runner/actions-runner path resolves correctly.
+    /usr/bin/ln -sfn /home/ubuntu /home/runner
 }
 
 

--- a/app/src/github_runner_image_builder/templates/cloud-init.sh.j2
+++ b/app/src/github_runner_image_builder/templates/cloud-init.sh.j2
@@ -172,6 +172,9 @@ function configure_system_users() {
     echo "Configuring runner user alias for GARM compatibility"
     UBUNTU_UID=$(/usr/bin/id -u ubuntu)
     UBUNTU_GID=$(/usr/bin/id -g ubuntu)
+    # --uid/--gid: share ubuntu's UID/GID so both users have identical file permissions.
+    # --no-create-home: skip creating /home/runner; runner's home is set to /home/ubuntu instead.
+    # 2>/dev/null || true: ignore errors (e.g. runner user already exists) without failing the script.
     /usr/sbin/useradd --uid "$UBUNTU_UID" --gid "$UBUNTU_GID" --no-create-home --home-dir /home/ubuntu runner 2>/dev/null || true
     /usr/sbin/usermod --append --groups docker,microk8s,lxd,sudo runner 2>/dev/null || true
 }

--- a/app/src/github_runner_image_builder/templates/cloud-init.sh.j2
+++ b/app/src/github_runner_image_builder/templates/cloud-init.sh.j2
@@ -179,7 +179,12 @@ function configure_system_users() {
     /usr/sbin/useradd --non-unique --uid "$UBUNTU_UID" --gid "$UBUNTU_GID" --no-create-home --home-dir /home/ubuntu runner 2>/dev/null || true
     /usr/sbin/usermod --append --groups docker,microk8s,lxd,sudo runner 2>/dev/null || true
     # Symlink /home/runner -> /home/ubuntu so GARM's hardcoded /home/runner/actions-runner path resolves correctly.
-    /usr/bin/ln -sfn /home/ubuntu /home/runner
+    # If /home/runner exists as a plain directory (not a symlink), remove it first; otherwise ln -sfnT would
+    # create the symlink inside the directory instead of replacing it.
+    # -T: treat destination as a file path, never as a directory target (prevents ln from creating the
+    #     symlink inside /home/runner if it exists as a directory after rmdir fails).
+    [ -d /home/runner ] && ! [ -L /home/runner ] && rmdir /home/runner 2>/dev/null || true
+    /usr/bin/ln -sfnT /home/ubuntu /home/runner
 }
 
 

--- a/app/src/github_runner_image_builder/templates/cloud-init.sh.j2
+++ b/app/src/github_runner_image_builder/templates/cloud-init.sh.j2
@@ -162,6 +162,14 @@ function configure_system_users() {
     /usr/sbin/groupadd -f microk8s
     /usr/sbin/groupadd -f docker
     /usr/sbin/usermod --append --groups docker,microk8s,lxd,sudo ubuntu
+
+    # Create runner user as alias to ubuntu for GARM compatibility.
+    # GARM expects a runner user with /home/runner/actions-runner path.
+    echo "Configuring runner user alias for GARM compatibility"
+    UBUNTU_UID=$(/usr/bin/id -u ubuntu)
+    UBUNTU_GID=$(/usr/bin/id -g ubuntu)
+    /usr/sbin/useradd --uid "$UBUNTU_UID" --gid "$UBUNTU_GID" --no-create-home --home-dir /home/ubuntu runner 2>/dev/null || true
+    /usr/sbin/usermod --append --groups docker,microk8s,lxd,sudo runner 2>/dev/null || true
 }
 
 

--- a/app/tests/integration/conftest.py
+++ b/app/tests/integration/conftest.py
@@ -152,11 +152,10 @@ def openstack_connection_fixture(
     with openstack.connect(cloud_name) as conn:
         yield conn
 
-        # TMP: remove cleanup
-        # images = conn.list_images()
-        # for image in images:
-        #     if str(image.name).startswith(test_id):
-        #         conn.delete_image(image)
+        images = conn.list_images()
+        for image in images:
+            if str(image.name).startswith(test_id):
+                conn.delete_image(image)
 
 
 @pytest.fixture(scope="module", name="dockerhub_mirror")

--- a/app/tests/integration/conftest.py
+++ b/app/tests/integration/conftest.py
@@ -152,10 +152,10 @@ def openstack_connection_fixture(
     with openstack.connect(cloud_name) as conn:
         yield conn
 
-        # images = conn.list_images()
-        # for image in images:
-        #     if str(image.name).startswith(test_id):
-        #         conn.delete_image(image)
+        images = conn.list_images()
+        for image in images:
+            if str(image.name).startswith(test_id):
+                conn.delete_image(image)
 
 
 @pytest.fixture(scope="module", name="dockerhub_mirror")

--- a/app/tests/integration/conftest.py
+++ b/app/tests/integration/conftest.py
@@ -152,10 +152,11 @@ def openstack_connection_fixture(
     with openstack.connect(cloud_name) as conn:
         yield conn
 
-        images = conn.list_images()
-        for image in images:
-            if str(image.name).startswith(test_id):
-                conn.delete_image(image)
+        # TMP: remove cleanup
+        # images = conn.list_images()
+        # for image in images:
+        #     if str(image.name).startswith(test_id):
+        #         conn.delete_image(image)
 
 
 @pytest.fixture(scope="module", name="dockerhub_mirror")

--- a/app/tests/integration/conftest.py
+++ b/app/tests/integration/conftest.py
@@ -152,10 +152,10 @@ def openstack_connection_fixture(
     with openstack.connect(cloud_name) as conn:
         yield conn
 
-        images = conn.list_images()
-        for image in images:
-            if str(image.name).startswith(test_id):
-                conn.delete_image(image)
+        # images = conn.list_images()
+        # for image in images:
+        #     if str(image.name).startswith(test_id):
+        #         conn.delete_image(image)
 
 
 @pytest.fixture(scope="module", name="dockerhub_mirror")

--- a/app/tests/unit/test_openstack_builder.py
+++ b/app/tests/unit/test_openstack_builder.py
@@ -887,15 +887,24 @@ function configure_system_users() {{
     # --non-unique: allow reusing ubuntu's UID (duplicate UIDs are rejected by default).
     # --uid/--gid: share ubuntu's UID/GID so both users have identical file permissions.
     # --no-create-home: skip creating /home/runner; runner's home is set to /home/ubuntu instead.
-    # 2>/dev/null || true: ignore errors (e.g. runner user already exists) without failing the script.
-    /usr/sbin/useradd --non-unique --uid "$UBUNTU_UID" --gid "$UBUNTU_GID" --no-create-home --home-dir /home/ubuntu runner 2>/dev/null || true
-    /usr/sbin/usermod --append --groups docker,microk8s,lxd,sudo runner 2>/dev/null || true
+    if /usr/bin/id -u runner >/dev/null 2>&1; then
+        echo "runner user already exists; ensuring UID/GID/home match ubuntu"
+        /usr/sbin/usermod --non-unique --uid "$UBUNTU_UID" --gid "$UBUNTU_GID" --home /home/ubuntu runner
+    else
+        /usr/sbin/useradd --non-unique --uid "$UBUNTU_UID" --gid "$UBUNTU_GID" --no-create-home --home-dir /home/ubuntu runner
+    fi
+    /usr/sbin/usermod --append --groups docker,microk8s,lxd,sudo runner
     # Symlink /home/runner -> /home/ubuntu so GARM's hardcoded /home/runner/actions-runner path resolves correctly.
-    # If /home/runner exists as a plain directory (not a symlink), remove it first; otherwise ln -sfnT would
-    # create the symlink inside the directory instead of replacing it.
-    # -T: treat destination as a file path, never as a directory target (prevents ln from creating the
-    #     symlink inside /home/runner if it exists as a directory after rmdir fails).
-    [ -d /home/runner ] && ! [ -L /home/runner ] && rmdir /home/runner 2>/dev/null || true
+    # If /home/runner exists as a plain directory (not a symlink), remove it first; otherwise ln -sfnT cannot
+    # replace it. A non-empty directory is an unexpected state, so fail with a clear error instead of letting
+    # ln fail later with a less specific message.
+    # -T: treat destination as a file path, never as a directory target.
+    if [ -d /home/runner ] && ! [ -L /home/runner ]; then
+        if ! rmdir /home/runner 2>/dev/null; then
+            echo "ERROR: /home/runner exists and is not empty; cannot replace it with a symlink to /home/ubuntu" >&2
+            return 1
+        fi
+    fi
     /usr/bin/ln -sfnT /home/ubuntu /home/runner
 }}
 

--- a/app/tests/unit/test_openstack_builder.py
+++ b/app/tests/unit/test_openstack_builder.py
@@ -884,6 +884,9 @@ function configure_system_users() {{
     echo "Configuring runner user alias for GARM compatibility"
     UBUNTU_UID=$(/usr/bin/id -u ubuntu)
     UBUNTU_GID=$(/usr/bin/id -g ubuntu)
+    # --uid/--gid: share ubuntu's UID/GID so both users have identical file permissions.
+    # --no-create-home: skip creating /home/runner; runner's home is set to /home/ubuntu instead.
+    # 2>/dev/null || true: ignore errors (e.g. runner user already exists) without failing the script.
     /usr/sbin/useradd --uid "$UBUNTU_UID" --gid "$UBUNTU_GID" --no-create-home --home-dir /home/ubuntu runner 2>/dev/null || true
     /usr/sbin/usermod --append --groups docker,microk8s,lxd,sudo runner 2>/dev/null || true
 }}

--- a/app/tests/unit/test_openstack_builder.py
+++ b/app/tests/unit/test_openstack_builder.py
@@ -878,6 +878,14 @@ function configure_system_users() {{
     /usr/sbin/groupadd -f microk8s
     /usr/sbin/groupadd -f docker
     /usr/sbin/usermod --append --groups docker,microk8s,lxd,sudo ubuntu
+
+    # Create runner user as alias to ubuntu for GARM compatibility.
+    # GARM expects a runner user with /home/runner/actions-runner path.
+    echo "Configuring runner user alias for GARM compatibility"
+    UBUNTU_UID=$(/usr/bin/id -u ubuntu)
+    UBUNTU_GID=$(/usr/bin/id -g ubuntu)
+    /usr/sbin/useradd --uid "$UBUNTU_UID" --gid "$UBUNTU_GID" --no-create-home --home-dir /home/ubuntu runner 2>/dev/null || true
+    /usr/sbin/usermod --append --groups docker,microk8s,lxd,sudo runner 2>/dev/null || true
 }}
 
 

--- a/app/tests/unit/test_openstack_builder.py
+++ b/app/tests/unit/test_openstack_builder.py
@@ -891,7 +891,12 @@ function configure_system_users() {{
     /usr/sbin/useradd --non-unique --uid "$UBUNTU_UID" --gid "$UBUNTU_GID" --no-create-home --home-dir /home/ubuntu runner 2>/dev/null || true
     /usr/sbin/usermod --append --groups docker,microk8s,lxd,sudo runner 2>/dev/null || true
     # Symlink /home/runner -> /home/ubuntu so GARM's hardcoded /home/runner/actions-runner path resolves correctly.
-    /usr/bin/ln -sfn /home/ubuntu /home/runner
+    # If /home/runner exists as a plain directory (not a symlink), remove it first; otherwise ln -sfnT would
+    # create the symlink inside the directory instead of replacing it.
+    # -T: treat destination as a file path, never as a directory target (prevents ln from creating the
+    #     symlink inside /home/runner if it exists as a directory after rmdir fails).
+    [ -d /home/runner ] && ! [ -L /home/runner ] && rmdir /home/runner 2>/dev/null || true
+    /usr/bin/ln -sfnT /home/ubuntu /home/runner
 }}
 
 

--- a/app/tests/unit/test_openstack_builder.py
+++ b/app/tests/unit/test_openstack_builder.py
@@ -884,11 +884,14 @@ function configure_system_users() {{
     echo "Configuring runner user alias for GARM compatibility"
     UBUNTU_UID=$(/usr/bin/id -u ubuntu)
     UBUNTU_GID=$(/usr/bin/id -g ubuntu)
+    # --non-unique: allow reusing ubuntu's UID (duplicate UIDs are rejected by default).
     # --uid/--gid: share ubuntu's UID/GID so both users have identical file permissions.
     # --no-create-home: skip creating /home/runner; runner's home is set to /home/ubuntu instead.
     # 2>/dev/null || true: ignore errors (e.g. runner user already exists) without failing the script.
-    /usr/sbin/useradd --uid "$UBUNTU_UID" --gid "$UBUNTU_GID" --no-create-home --home-dir /home/ubuntu runner 2>/dev/null || true
+    /usr/sbin/useradd --non-unique --uid "$UBUNTU_UID" --gid "$UBUNTU_GID" --no-create-home --home-dir /home/ubuntu runner 2>/dev/null || true
     /usr/sbin/usermod --append --groups docker,microk8s,lxd,sudo runner 2>/dev/null || true
+    # Symlink /home/runner -> /home/ubuntu so GARM's hardcoded /home/runner/actions-runner path resolves correctly.
+    /usr/bin/ln -sfn /home/ubuntu /home/runner
 }}
 
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,9 @@
 <!-- vale Canonical.007-Headings-sentence-case = NO -->
 
+## [#TBD Fix GARM image incompatibility]
+
+- Add `runner` user as an alias to the `ubuntu` user (same UID/GID, same home directory) so GARM can boot runners from images produced by this charm.
+
 ## [#221 Add resource recommendation for charm deployment](https://github.com/canonical/github-runner-image-builder-operator/pull/221)
 
 <!-- vale Canonical.013-Spell-out-numbers-below-10 = NO -->

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,8 +1,9 @@
 <!-- vale Canonical.007-Headings-sentence-case = NO -->
 
-## [#TBD Fix GARM image incompatibility]
+## [#223 Fix GARM image incompatibility](https://github.com/canonical/github-runner-image-builder-operator/pull/223) (2026-05-27)
 
 - Add `runner` user as an alias to the `ubuntu` user (same UID/GID, same home directory) so GARM can boot runners from images produced by this charm.
+
 ## [#222 Add PPA for .NET backport during image building](https://github.com/canonical/github-runner-image-builder-operator/pull/222) (2026-05-22)
 
 - Add .NET PPA in image building. This allows wider range of .NET version to be installed.
@@ -10,6 +11,7 @@
 ## [#221 Add resource recommendation for charm deployment](https://github.com/canonical/github-runner-image-builder-operator/pull/221)
 
 <!-- vale Canonical.013-Spell-out-numbers-below-10 = NO -->
+
 - Add 2 vCPUs, 8 GiB RAM, and 20 GiB disk OpenStack flavor recommendation.
 <!-- vale Canonical.013-Spell-out-numbers-below-10 = YES -->
 

--- a/docs/reference/charm-architecture.md
+++ b/docs/reference/charm-architecture.md
@@ -108,15 +108,15 @@ storing OpenStack credentials on disk and initializing the image-builder applica
 2. [config-changed](https://documentation.ubuntu.com/juju/3.6/reference/hook/#config-changed): The configuration of the charm has changed. The charm applies the configuration (e.g. changes to proxy or OpenStack credentials).
 3. `run`: This is a custom event that is periodically triggered by a cron job. It is used to call the image-builder application to build the image.
 4. `run-action`: This is an action event fired by the user to manually trigger the image-builder to build the image.
-5. `image-relation-changed`: This is a [relation event](https://juju.is/docs/sdk/relation-events) that fires when relation data changes. It also triggers the image-builder to build the image.
+5. `image-relation-changed`: This is a [relation event](https://documentation.ubuntu.com/juju/3.6/reference/hook/) that fires when relation data changes. It also triggers the image-builder to build the image.
 Once the build is complete, the image-builder will upload the image taking into account the newly changed relation data (e.g. if the OpenStack project has changed).
 
-> See more about events in the Juju docs: [Event](https://juju.is/docs/sdk/event)
+> See more about events in the ops docs: [Event](https://documentation.ubuntu.com/juju/3.6/reference/hook/)
 
 ## Charm code overview
 
 The `src/charm.py` is the default entry point for a charm and has the GithubRunnerImageBuilderCharm Python class which inherits from CharmBase. CharmBase is the base class 
-from which all charms are formed, defined by [Ops](https://juju.is/docs/sdk/ops) (Python framework for developing charms).
+from which all charms are formed, defined by [Ops](https://documentation.ubuntu.com/ops/latest/) (Python framework for developing charms).
 
 > See more in the Juju docs: [Charm](https://documentation.ubuntu.com/juju/3.6/reference/charm/)
 

--- a/docs/reference/charm-architecture.md
+++ b/docs/reference/charm-architecture.md
@@ -108,7 +108,7 @@ storing OpenStack credentials on disk and initializing the image-builder applica
 2. [config-changed](https://documentation.ubuntu.com/juju/3.6/reference/hook/#config-changed): The configuration of the charm has changed. The charm applies the configuration (e.g. changes to proxy or OpenStack credentials).
 3. `run`: This is a custom event that is periodically triggered by a cron job. It is used to call the image-builder application to build the image.
 4. `run-action`: This is an action event fired by the user to manually trigger the image-builder to build the image.
-5. `image-relation-changed`: This is a [relation event](https://documentation.ubuntu.com/juju/3.6/reference/hook/) that fires when relation data changes. It also triggers the image-builder to build the image.
+5. `image-relation-changed`: This is a [relation event](https://documentation.ubuntu.com/juju/3.6/reference/hook/#relation-hooks) that fires when relation data changes. It also triggers the image-builder to build the image.
 Once the build is complete, the image-builder will upload the image taking into account the newly changed relation data (e.g. if the OpenStack project has changed).
 
 > See more about events in the ops docs: [Event](https://documentation.ubuntu.com/juju/3.6/reference/hook/)


### PR DESCRIPTION
1. Applicable spec: [ISD278 - Design of MVP GitHub runner charm with GARM as workload](https://docs.google.com/document/d/12QelsLpxl5Q1vCAQu6kqjtTJ9szyliAJshBgdVwILeQ/edit?usp=sharing)

### Overview

Adds a `runner` user as an alias to the `ubuntu` user in the cloud-init script. Both users share the same UID, GID, and home directory (`/home/ubuntu`), so `/home/runner/actions-runner` resolves to the same path as `/home/ubuntu/actions-runner`.

### Rationale

GARM (GitHub Actions Runner Manager) expects a `runner` user and looks for the runner application at `/home/runner/actions-runner`. The current image builder only creates an `ubuntu` user, causing GARM to fail when attempting to boot runners from the produced images.

The user alias approach was chosen over alternatives (e.g. an opt-in `garm-support` databag field) because it requires a single, minimal change with zero impact on existing deployments.

### Juju Events Changes

None.

### Module Changes

- `app/src/github_runner_image_builder/templates/cloud-init.sh.j2`: Added `runner` user creation in `configure_system_users()`. The runner user is created with the same UID/GID as `ubuntu` and the same home directory, then added to the same groups (docker, microk8s, lxd, sudo).

### Library Changes

None.

### Checklist

- [ ] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation for charmhub is updated.
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `senior-review-required`, `documentation`)
- [x] The docs/changelog.md is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)
- [x] The application version is incremented in `app/pyproject.toml`