### PR TITLE
WIP: feat: add riscv64 architecture support

### DIFF
--- a/app/src/github_runner_image_builder/cloud_image.py
+++ b/app/src/github_runner_image_builder/cloud_image.py
@@ -20,7 +20,7 @@ from github_runner_image_builder.utils import retry
 
 logger = logging.getLogger(__name__)
 
-SupportedBaseImageArch = typing.Literal["amd64", "arm64", "s390x", "ppc64el"]
+SupportedBaseImageArch = typing.Literal["amd64", "arm64", "s390x", "ppc64el", "riscv64"]
 
 CHECKSUM_BUF_SIZE = 65536  # 65kb
 
@@ -95,6 +95,8 @@ def _get_supported_runner_arch(arch: Arch) -> SupportedBaseImageArch:
             return "s390x"
         case Arch.PPC64LE:
             return "ppc64el"  # cloud-images.ubuntu.com uses ppc64el instead of ppc64le
+        case Arch.RISCV64:
+            return "riscv64"
         case _:
             raise UnsupportedArchitectureError(f"Detected system arch: {arch} is unsupported.")
 

--- a/app/src/github_runner_image_builder/config.py
+++ b/app/src/github_runner_image_builder/config.py
@@ -20,12 +20,14 @@ class Arch(str, Enum):
         X64: Represents an X64/AMD64 system architecture.
         S390X: Represents an S390X system architecture.
         PPC64LE: Represents a PPC64LE system architecture.
+        RISCV64: Represents a RISCV64 system architecture.
     """
 
     ARM64 = "arm64"
     X64 = "x64"
     S390X = "s390x"
     PPC64LE = "ppc64le"
+    RISCV64 = "riscv64"
 
     def to_openstack(self) -> str:
         """Convert the architecture to OpenStack compatible arch string.
@@ -42,6 +44,8 @@ class Arch(str, Enum):
                 return "s390x"
             case Arch.PPC64LE:
                 return "ppc64le"
+            case Arch.RISCV64:
+                return "riscv64"
         raise ValueError  # pragma: nocover
 
 
@@ -139,6 +143,14 @@ LOG_LEVELS = tuple(
 )
 
 FORK_RUNNER_BINARY_REPO = "canonical/github-actions-runner"
+
+# Per-architecture overrides for the GitHub repository that publishes the runner
+# release tarballs. The default (canonical/github-actions-runner) is used for any
+# architecture not listed here. riscv64 is published on a fork until the tarball
+# is folded into the canonical fork's release pipeline.
+RUNNER_BINARY_REPO_OVERRIDES: dict[Arch, str] = {
+    Arch.RISCV64: "vhaudiquet/actions-runner-riscv",
+}
 
 
 @dataclasses.dataclass

--- a/app/src/github_runner_image_builder/openstack_builder.py
+++ b/app/src/github_runner_image_builder/openstack_builder.py
@@ -42,6 +42,7 @@ from github_runner_image_builder import cloud_image, config, store
 from github_runner_image_builder.config import (
     FORK_RUNNER_BINARY_REPO,
     IMAGE_DEFAULT_APT_PACKAGES,
+    RUNNER_BINARY_REPO_OVERRIDES,
     S390X_PPC64LE_ADDITIONAL_APT_PACKAGES,
     Arch,
     BaseImage,
@@ -77,6 +78,10 @@ EXTERNAL_SCRIPT_RUN_TIMEOUT = 60 * 60  # 60 minutes
 MIN_CPU = 2
 MIN_RAM = 1024  # M
 MIN_DISK = 20  # G
+
+# Focal does not publish riscv64 cloud images on cloud-images.ubuntu.com, so the
+# focal base cannot be seeded for riscv64.
+RISCV64_UNSUPPORTED_BASES = {BaseImage.FOCAL}
 
 # We saw an issue with arm noble images with the latest release date, so we are using a fixed date.
 NOBLE_ARM64_RELEASE_DATE = date(2025, 11, 13)
@@ -128,59 +133,30 @@ def initialize(arch: Arch, cloud_name: str, prefix: str) -> None:
         prefix: The prefix to use for OpenStack resource names.
     """
     logger.info("Initializing external builder.")
-    logger.info("Downloading Focal image.")
-    focal_image_path = cloud_image.download_and_validate_image(
-        arch=arch, base_image=BaseImage.FOCAL
+    unsupported_bases = (
+        RISCV64_UNSUPPORTED_BASES if arch == Arch.RISCV64 else set()
     )
-    logger.info("Downloading Jammy image.")
-    jammy_image_path = cloud_image.download_and_validate_image(
-        arch=arch, base_image=BaseImage.JAMMY
-    )
-    logger.info("Downloading Noble image.")
-    # 2025/11/18 We've seen issues with the latest noble arm64 image, the decision is to keep the
-    # option to pin a specific release date if needed in the future. The comment code snippet below
-    # is kept for reference. If we want to pin a specific date again, we can expose it as a config
-    # option on the charm side to enable it on the operations side.
-    noble_release_date = None  # NOBLE_ARM64_RELEASE_DATE if arch == Arch.ARM64 else None
-    noble_image_path = cloud_image.download_and_validate_image(
-        arch=arch, base_image=BaseImage.NOBLE, release_date=noble_release_date
-    )
-    logger.info("Downloading Resolute image.")
-    resolute_image_path = cloud_image.download_and_validate_image(
-        arch=arch, base_image=BaseImage.RESOLUTE
-    )
-    logger.info("Uploading Focal image.")
-    store.upload_image(
-        arch=arch,
-        cloud_name=cloud_name,
-        image_name=_get_base_image_name(arch=arch, base=BaseImage.FOCAL, prefix=prefix),
-        image_path=focal_image_path,
-        keep_revisions=1,
-    )
-    logger.info("Uploading Jammy image.")
-    store.upload_image(
-        arch=arch,
-        cloud_name=cloud_name,
-        image_name=_get_base_image_name(arch=arch, base=BaseImage.JAMMY, prefix=prefix),
-        image_path=jammy_image_path,
-        keep_revisions=1,
-    )
-    logger.info("Uploading Noble image.")
-    store.upload_image(
-        arch=arch,
-        cloud_name=cloud_name,
-        image_name=_get_base_image_name(arch=arch, base=BaseImage.NOBLE, prefix=prefix),
-        image_path=noble_image_path,
-        keep_revisions=1,
-    )
-    logger.info("Uploading Resolute image.")
-    store.upload_image(
-        arch=arch,
-        cloud_name=cloud_name,
-        image_name=_get_base_image_name(arch=arch, base=BaseImage.RESOLUTE, prefix=prefix),
-        image_path=resolute_image_path,
-        keep_revisions=1,
-    )
+    bases: list[BaseImage] = [
+        base for base in BaseImage if base not in unsupported_bases
+    ]
+    for base in bases:
+        logger.info("Downloading %s image.", base.value.capitalize())
+        # 2025/11/18 We've seen issues with the latest noble arm64 image, the decision is to keep the
+        # option to pin a specific release date if needed in the future. The comment code snippet below
+        # is kept for reference. If we want to pin a specific date again, we can expose it as a config
+        # option on the charm side to enable it on the operations side.
+        release_date = None  # NOBLE_ARM64_RELEASE_DATE if arch == Arch.ARM64 else None
+        image_path = cloud_image.download_and_validate_image(
+            arch=arch, base_image=base, release_date=release_date
+        )
+        logger.info("Uploading %s image.", base.value.capitalize())
+        store.upload_image(
+            arch=arch,
+            cloud_name=cloud_name,
+            image_name=_get_base_image_name(arch=arch, base=base, prefix=prefix),
+            image_path=image_path,
+            keep_revisions=1,
+        )
     with openstack.connect(cloud=cloud_name) as conn:
         _create_keypair(conn=conn, prefix=prefix)
         logger.info("Creating security group %s.", SHARED_SECURITY_GROUP_NAME)
@@ -558,7 +534,9 @@ def _generate_cloud_init_script(
         HWE_VERSION=BaseImage.get_version(image_config.base),
         RUNNER_VERSION=image_config.runner_version,
         RUNNER_ARCH=image_config.arch.value,
-        RUNNER_BINARY_REPO=FORK_RUNNER_BINARY_REPO,
+        RUNNER_BINARY_REPO=RUNNER_BINARY_REPO_OVERRIDES.get(
+            image_config.arch, FORK_RUNNER_BINARY_REPO
+        ),
     )
 
 

--- a/app/tests/unit/test_cli.py
+++ b/app/tests/unit/test_cli.py
@@ -95,6 +95,7 @@ def test_main(cli_runner: CliRunner, action: str):
         pytest.param("x64", config.Arch.X64, id="amd64"),
         pytest.param("s390x", config.Arch.S390X, id="s390x"),
         pytest.param("ppc64le", config.Arch.PPC64LE, id="ppc64le"),
+        pytest.param("riscv64", config.Arch.RISCV64, id="riscv64"),
     ],
 )
 def test_initialize(

--- a/app/tests/unit/test_cloud_image.py
+++ b/app/tests/unit/test_cloud_image.py
@@ -179,6 +179,7 @@ def test__get_supported_runner_arch_unsupported_error():
         pytest.param(Arch.X64, "amd64", id="AMD64"),
         pytest.param(Arch.S390X, "s390x", id="S390X"),
         pytest.param(Arch.PPC64LE, "ppc64el", id="PPC64LE"),
+        pytest.param(Arch.RISCV64, "riscv64", id="RISCV64"),
     ],
 )
 def test__get_supported_runner_arch(arch: Arch, expected: SupportedBaseImageArch):

--- a/app/tests/unit/test_config.py
+++ b/app/tests/unit/test_config.py
@@ -22,6 +22,7 @@ from github_runner_image_builder.config import (
         pytest.param(Arch.X64, "x86_64", id="amd64"),
         pytest.param(Arch.S390X, "s390x", id="s390x"),
         pytest.param(Arch.PPC64LE, "ppc64le", id="ppc64le"),
+        pytest.param(Arch.RISCV64, "riscv64", id="riscv64"),
     ],
 )
 def test_arch_openstack_conversion(arch: Arch, expected: str):

--- a/app/tests/unit/test_openstack_builder.py
+++ b/app/tests/unit/test_openstack_builder.py
@@ -20,7 +20,11 @@ import tenacity
 import yaml
 
 from github_runner_image_builder import cloud_image, errors, openstack_builder, store
-from github_runner_image_builder.config import Arch
+from github_runner_image_builder.config import (
+    FORK_RUNNER_BINARY_REPO,
+    RUNNER_BINARY_REPO_OVERRIDES,
+    Arch,
+)
 from github_runner_image_builder.errors import ExternalScriptError
 from github_runner_image_builder.openstack_builder import EXTERNAL_SCRIPT_PATH
 
@@ -147,6 +151,30 @@ def test_initialize_release_date(monkeypatch: pytest.MonkeyPatch, arch: Arch):
     archs_from_calls = {call[1]["arch"] for call in download_mock.call_args_list}
     assert openstack_builder.BaseImage.NOBLE in base_images_from_calls
     assert arch in archs_from_calls
+
+
+def test_initialize_riscv64_skips_focal(monkeypatch: pytest.MonkeyPatch):
+    """
+    arrange: given monkeypatched cloud_image, store and openstack module functions.
+    act: when initialize is called for riscv64.
+    assert: focal base image is not downloaded/uploaded (no riscv64 focal cloud image exists),
+        while jammy/noble/resolute are.
+    """
+    monkeypatch.setattr(cloud_image, "download_and_validate_image", (download_mock := MagicMock()))
+    monkeypatch.setattr(store, "upload_image", MagicMock())
+    monkeypatch.setattr(openstack_builder.openstack, "connect", MagicMock())
+    monkeypatch.setattr(openstack_builder, "_create_keypair", MagicMock())
+    monkeypatch.setattr(openstack_builder, "_create_security_group", MagicMock())
+
+    prefix = secrets.token_hex(8)
+    cloud_name = "test-cloud"
+    openstack_builder.initialize(arch=Arch.RISCV64, cloud_name=cloud_name, prefix=prefix)
+
+    base_images_from_calls = {call[1]["base_image"] for call in download_mock.call_args_list}
+    assert openstack_builder.BaseImage.FOCAL not in base_images_from_calls
+    assert openstack_builder.BaseImage.JAMMY in base_images_from_calls
+    assert openstack_builder.BaseImage.NOBLE in base_images_from_calls
+    assert openstack_builder.BaseImage.RESOLUTE in base_images_from_calls
 
 
 def test__create_keypair_already_exists(monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path):
@@ -676,6 +704,7 @@ def test__determine_network(network_name: str | None):
             ["dotnet-runtime-8.0"],
             id="ppc64le",
         ),
+        pytest.param(openstack_builder.Arch.RISCV64, [], id="riscv64"),
     ],
 )
 def test__generate_cloud_init_script(
@@ -914,7 +943,7 @@ apt_packages="build-essential cargo docker.io gh jq npm pkg-config python-is-pyt
 hwe_version="22.04"
 github_runner_version=""
 github_runner_arch="{arch.value}"
-runner_binary_repo="canonical/github-actions-runner"
+runner_binary_repo="{RUNNER_BINARY_REPO_OVERRIDES.get(arch, FORK_RUNNER_BINARY_REPO)}"
 
 configure_proxy "$proxy"
 install_apt_packages "$apt_packages" "$hwe_version"

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -73,8 +73,8 @@ config:
       type: string
       description: |
         The image architecture to build for using external builder. Can be one of "amd64", "arm64", "s390x", 
-        "ppc64le" (alternatively "ppc64el").
-        Support for "s390x" and "ppc64el" is considered experimental.
+        "ppc64le" (alternatively "ppc64el"), or "riscv64".
+        Support for "s390x", "ppc64el" and "riscv64" is considered experimental.
     base-image:
       type: string
       default: noble

--- a/src/state.py
+++ b/src/state.py
@@ -20,6 +20,7 @@ ARCHITECTURES_ARM64 = {"aarch64", "arm64"}
 ARCHITECTURES_S390X = {"s390x"}
 ARCHITECTURES_PPC64LE = {"ppc64le", "ppc64el"}
 ARCHITECTURES_X86 = {"x86_64", "amd64", "x64"}
+ARCHITECTURES_RISCV64 = {"riscv64"}
 CLOUD_NAME = "builder"
 LTS_IMAGE_VERSION_TAG_MAP = {
     "20.04": "focal",
@@ -80,6 +81,7 @@ class Arch(str, Enum):
         X64: Represents an X64/AMD64 system architecture.
         S390X: Represents an S390X system architecture.
         PPC64LE: Represents an PPC64LE system architecture.
+        RISCV64: Represents an RISCV64 system architecture.
     """
 
     def __str__(self) -> str:
@@ -94,6 +96,7 @@ class Arch(str, Enum):
     X64 = "x64"
     S390X = "s390x"
     PPC64LE = "ppc64le"
+    RISCV64 = "riscv64"
 
     @classmethod
     def from_charm(cls, charm: ops.CharmBase) -> "Arch":
@@ -120,6 +123,8 @@ class Arch(str, Enum):
                 return Arch.S390X
             case arch if arch in ARCHITECTURES_PPC64LE:
                 return Arch.PPC64LE
+            case arch if arch in ARCHITECTURES_RISCV64:
+                return Arch.RISCV64
             case _:
                 raise UnsupportedArchitectureError(msg=f"Unsupported {arch=}")
 

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -41,6 +41,7 @@ def patch_juju_version_29_fixture(monkeypatch: pytest.MonkeyPatch):
         pytest.param("amd64", state.Arch.X64, id="amd64"),
         pytest.param("s390x", state.Arch.S390X, id="s390x"),
         pytest.param("ppc64le", state.Arch.PPC64LE, id="ppc64le"),
+        pytest.param("riscv64", state.Arch.RISCV64, id="riscv64"),
     ],
 )
 def test_arch_from_charm(arch: str, expected: state.Arch):
@@ -77,6 +78,7 @@ def test_arch_from_charm_unsupported():
         pytest.param(state.Arch.X64, state.Arch.X64.value),
         pytest.param(state.Arch.S390X, state.Arch.S390X.value),
         pytest.param(state.Arch.PPC64LE, state.Arch.PPC64LE.value),
+        pytest.param(state.Arch.RISCV64, state.Arch.RISCV64.value),
     ],
 )
 def test_arch_str(arch: state.Arch, expected_str: str):


### PR DESCRIPTION
### Overview

Add riscv64 as a supported image architecture, treating it like arm64 (self-contained runner tarball, no system dotnet needed in the image).

The riscv64 GitHub Actions runner tarball is a self-contained build produced from the canonical/github-actions-runner fork (with a riscv64 patch) using the community dotnet-sdk-riscv snap at build time. The produced tarball bundles its own .NET runtime, so — unlike s390x/ ppc64le — no dotnet-runtime apt package is installed in the runner image and riscv64 is excluded from S390X_PPC64LE_ADDITIONAL_APT_PACKAGES.

Changes:
```
config.py (app):
  - Add RISCV64 to the Arch enum and Arch.to_openstack().
  - Add RUNNER_BINARY_REPO_OVERRIDES to publish the runner tarball from a fork until it is folded into the canonical fork's release pipeline (riscv64 -> vhaudiquet/actions-runner-riscv).

cloud_image.py (app):
  - Map Arch.RISCV64 -> "riscv64" in _get_supported_runner_arch() and add it to SupportedBaseImageArch.

openstack_builder.py (app):
  - _generate_cloud_init_script resolves the runner binary repo via the per-arch override (falling back to canonical/github-actions-runner).
  - Refactor initialize() to iterate over the supported bases, skipping focal for riscv64 (no riscv64 focal cloud image exists on cloud-images.ubuntu.com).

state.py (charm):
  - Add RISCV64 to the charm-side Arch enum, ARCHITECTURES_RISCV64 set, and Arch.from_charm().

charmcraft.yaml:
  - Document riscv64 in the architecture config option description.
```

Tests:
  - Add riscv64 parametrized cases across the app and charm unit tests.
  - Add test_initialize_riscv64_skips_focal covering the focal skip.

### Rationale

RISCV64 hardware will be coming to Toronto and then PS10. We need all Canonical and other software to be fully supported for this. A lot of software is using GitHub runners for tests and build. We need to support GitHub runners, but they themselves depend on .NET which depends on hardware builders. So we need to break the chain by bootstrapping something.

### Juju Events Changes

None. No Juju events or hooks were modified. The change is internal to the build logic and configuration parsing.

### Module Changes

 - src/state.py
 - app/src/github_runner_image_builder/config.py
 - app/src/github_runner_image_builder/cloud_image.py
 - app/src/github_runner_image_builder/openstack_builder.py

(see full change description above)

### Library Changes

None.

### Checklist

- [x] The [charm style guide](https://documentation.ubuntu.com/juju/3.6/reference/charm) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation for charmhub is updated.
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `senior-review-required`, `documentation`)
- [ ] The docs/changelog.md is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)
- [ ] The application version is incremented in `app/pyproject.toml`

Still WIP, will try to comply with all requirements above
<!-- Explanation for any unchecked items above -->
