### PR TITLE
docs: add relation-endpoints reference page (ISD-5960)

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,7 @@ DevOps or SRE teams through Juju's clean interface.
 |--|--|
 | **Get started** | [Deploy the GitHub runner image builder charm](https://charmhub.io/github-runner-image-builder/docs/tutorial-quick-start) |
 | **Deployment** | [Configure base image](https://charmhub.io/github-runner-image-builder/docs/how-to-configure-base-image) \| [Configure build interval](https://charmhub.io/github-runner-image-builder/docs/how-to-configure-build-interval) \| [Configure revision history](https://charmhub.io/github-runner-image-builder/docs/how-to-configure-revision-history) \| [Pin GitHub runner version](https://charmhub.io/github-runner-image-builder/docs/how-to-pin-github-runner-version) |
-| **Design** | [Charm architecture](https://charmhub.io/github-runner-image-builder/docs/explanation-charm-architecture) |
+| **Reference** | [Relation endpoints](https://charmhub.io/github-runner-image-builder/docs/reference-relation-endpoints) \| [Charm architecture](https://charmhub.io/github-runner-image-builder/docs/explanation-charm-architecture) |
 
 ## How this documentation is organized
 
@@ -24,7 +24,7 @@ This documentation follows the [Diátaxis](https://diataxis.fr/) structure:
 
 - The [Tutorial](https://charmhub.io/github-runner-image-builder/docs/tutorial-quick-start) takes you step-by-step through deploying the charm and building your first runner image.
 - [How-to guides](https://charmhub.io/github-runner-image-builder/docs/how-to-configure-base-image) assume basic familiarity with the charm. They cover configuring, operating, and upgrading your deployment.
-- [Reference](https://charmhub.io/github-runner-image-builder/docs/explanation-charm-architecture) provides technical details on the charm architecture and design.
+- [Reference](https://charmhub.io/github-runner-image-builder/docs/reference-relation-endpoints) provides technical details including relation endpoints and charm architecture.
 
 ## Contributing to this documentation
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,7 @@ DevOps or SRE teams through Juju's clean interface.
 |--|--|
 | **Get started** | [Deploy the GitHub runner image builder charm](https://charmhub.io/github-runner-image-builder/docs/tutorial-quick-start) |
 | **Deployment** | [Configure base image](https://charmhub.io/github-runner-image-builder/docs/how-to-configure-base-image) \| [Configure build interval](https://charmhub.io/github-runner-image-builder/docs/how-to-configure-build-interval) \| [Configure revision history](https://charmhub.io/github-runner-image-builder/docs/how-to-configure-revision-history) \| [Pin GitHub runner version](https://charmhub.io/github-runner-image-builder/docs/how-to-pin-github-runner-version) |
-| **Reference** | [Relation endpoints](https://charmhub.io/github-runner-image-builder/docs/reference-relation-endpoints) \| [Charm architecture](https://charmhub.io/github-runner-image-builder/docs/reference-charm-architecture) |
+| **Reference** | [Relation endpoints](reference/relation-endpoints.md) \| [Charm architecture](https://charmhub.io/github-runner-image-builder/docs/explanation-charm-architecture) |
 
 ## How this documentation is organized
 
@@ -24,7 +24,7 @@ This documentation follows the [Diátaxis](https://diataxis.fr/) structure:
 
 - The [Tutorial](https://charmhub.io/github-runner-image-builder/docs/tutorial-quick-start) takes you step-by-step through deploying the charm and building your first runner image.
 - [How-to guides](https://charmhub.io/github-runner-image-builder/docs/how-to-configure-base-image) assume basic familiarity with the charm. They cover configuring, operating, and upgrading your deployment.
-- [Reference](https://charmhub.io/github-runner-image-builder/docs/reference-relation-endpoints) provides technical details including relation endpoints and charm architecture.
+- [Reference](reference/relation-endpoints.md) provides technical details including relation endpoints and charm architecture.
 
 ## Contributing to this documentation
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,7 @@ DevOps or SRE teams through Juju's clean interface.
 |--|--|
 | **Get started** | [Deploy the GitHub runner image builder charm](https://charmhub.io/github-runner-image-builder/docs/tutorial-quick-start) |
 | **Deployment** | [Configure base image](https://charmhub.io/github-runner-image-builder/docs/how-to-configure-base-image) \| [Configure build interval](https://charmhub.io/github-runner-image-builder/docs/how-to-configure-build-interval) \| [Configure revision history](https://charmhub.io/github-runner-image-builder/docs/how-to-configure-revision-history) \| [Pin GitHub runner version](https://charmhub.io/github-runner-image-builder/docs/how-to-pin-github-runner-version) |
-| **Reference** | [Relation endpoints](https://charmhub.io/github-runner-image-builder/docs/reference-relation-endpoints) \| [Charm architecture](https://charmhub.io/github-runner-image-builder/docs/explanation-charm-architecture) |
+| **Reference** | [Relation endpoints](https://charmhub.io/github-runner-image-builder/docs/reference-relation-endpoints) \| [Charm architecture](https://charmhub.io/github-runner-image-builder/docs/reference-charm-architecture) |
 
 ## How this documentation is organized
 

--- a/docs/reference/relation-endpoints.md
+++ b/docs/reference/relation-endpoints.md
@@ -8,7 +8,7 @@ This page describes the relation endpoints supported by the GitHub Runner Image 
 * **Supported charms**: [GitHub Runner operator](https://charmhub.io/github-runner)
 
 Provides built VM images to charms that manage GitHub self-hosted runners. When a relation is
-joined, the image builder shares the latest built image ID and its associated tags (e.g. `amd64`,
+joined, the image builder shares the latest built image ID and its associated tags (e.g. `x64`,
 `jammy`) via the relation data.
 
 The relation data published by this charm includes:
@@ -16,7 +16,7 @@ The relation data published by this charm includes:
 | Key | Type | Description |
 |-----|------|-------------|
 | `id` | string | ID of the latest built image. |
-| `tags` | string | Comma-separated tags describing the image (e.g. `amd64,jammy`). |
+| `tags` | string | Comma-separated tags describing the image (e.g. `x64,jammy`). |
 | `images` | JSON string | List of image objects, each with `id` and `tags` fields. |
 
 Example integrate command:

--- a/docs/reference/relation-endpoints.md
+++ b/docs/reference/relation-endpoints.md
@@ -1,0 +1,41 @@
+# Relation endpoints
+
+This page describes the relation endpoints supported by the GitHub Runner Image Builder charm.
+
+## `image` (provides)
+
+* **Interface**: `github_runner_image_v0`
+* **Supported charms**: [GitHub Runner operator](https://charmhub.io/github-runner)
+
+Provides built VM images to charms that manage GitHub self-hosted runners. When a relation is
+joined, the image builder shares the latest built image ID and its associated tags (e.g. `amd64`,
+`jammy`) via the relation data.
+
+The relation data published by this charm includes:
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `id` | string | ID of the latest built image. |
+| `tags` | string | Comma-separated tags describing the image (e.g. `amd64,jammy`). |
+| `images` | JSON string | List of image objects, each with `id` and `tags` fields. |
+
+Example integrate command:
+
+```bash
+juju integrate github-runner-image-builder:image github-runner:image
+```
+
+## `cos-agent` (provides)
+
+* **Interface**: `cos_agent`
+* **Supported charms**: [Grafana Agent operator](https://charmhub.io/grafana-agent)
+
+Integrates with the [Canonical Observability Stack (COS)](https://charmhub.io/topics/canonical-observability-stack)
+via the Grafana Agent operator. Enables collection and forwarding of metrics, logs, and traces from
+the image builder to your COS deployment.
+
+Example integrate command:
+
+```bash
+juju integrate github-runner-image-builder:cos-agent grafana-agent:cos-agent
+```

--- a/docs/reference/relation-endpoints.md
+++ b/docs/reference/relation-endpoints.md
@@ -8,7 +8,7 @@ This page describes the relation endpoints supported by the GitHub Runner Image 
 * **Supported charms**: [GitHub Runner operator](https://charmhub.io/github-runner)
 
 Provides built VM images to charms that manage GitHub self-hosted runners. When a relation is
-joined, the image builder shares the latest built image ID and its associated tags (e.g. `x64`,
+joined, the image builder shares the latest built image ID and its associated tags (for example, `x64`,
 `jammy`) via the relation data.
 
 The relation data published by this charm includes:
@@ -16,7 +16,7 @@ The relation data published by this charm includes:
 | Key | Type | Description |
 |-----|------|-------------|
 | `id` | string | ID of the latest built image. |
-| `tags` | string | Comma-separated tags describing the image (e.g. `x64,jammy`). |
+| `tags` | string | Comma-separated tags describing the image (for example, `x64,jammy`). |
 | `images` | JSON string | List of image objects, each with `id` and `tags` fields. |
 
 Example integrate command:


### PR DESCRIPTION
### Overview

Add a reference page for the relation endpoints. 



### Rationale

Fixes #227 



### Checklist

- [ ] The [charm style guide](https://documentation.ubuntu.com/juju/3.6/reference/charm) was applied
- [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation for charmhub is updated.
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `senior-review-required`, `documentation`)
- [ ] The docs/changelog.md is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)
- [ ] The application version is incremented in `app/pyproject.toml`

<!-- Explanation for any unchecked items above -->
