### PR TITLE
fix(image): enable linger for the runner user

### DIFF
--- a/app/src/github_runner_image_builder/templates/cloud-init.sh.j2
+++ b/app/src/github_runner_image_builder/templates/cloud-init.sh.j2
@@ -195,7 +195,7 @@ function configure_system_users() {
     /usr/sbin/groupadd -f docker
     /usr/sbin/usermod --append --groups docker,microk8s,lxd,sudo ubuntu
     # snapd creates an app's tracking cgroup through the per-user systemd manager, and logind
-    # removes /run/user/1000 once the last session ends. A runner started as a system service
+    # removes /run/user/<uid> once the last session ends. A runner started as a system service
     # has no login session, so linger is what keeps both alive.
     /usr/bin/loginctl enable-linger ubuntu
 

--- a/app/src/github_runner_image_builder/templates/cloud-init.sh.j2
+++ b/app/src/github_runner_image_builder/templates/cloud-init.sh.j2
@@ -194,6 +194,10 @@ function configure_system_users() {
     /usr/sbin/groupadd -f microk8s
     /usr/sbin/groupadd -f docker
     /usr/sbin/usermod --append --groups docker,microk8s,lxd,sudo ubuntu
+    # snapd creates an app's tracking cgroup through the per-user systemd manager, and logind
+    # removes /run/user/1000 once the last session ends. A runner started as a system service
+    # has no login session, so linger is what keeps both alive.
+    /usr/bin/loginctl enable-linger ubuntu
 
     # Create runner user as alias to ubuntu for GARM compatibility.
     # GARM expects a runner user with /home/runner/actions-runner path.

--- a/app/tests/unit/test_openstack_builder.py
+++ b/app/tests/unit/test_openstack_builder.py
@@ -927,7 +927,7 @@ function configure_system_users() {{
     /usr/sbin/groupadd -f docker
     /usr/sbin/usermod --append --groups docker,microk8s,lxd,sudo ubuntu
     # snapd creates an app's tracking cgroup through the per-user systemd manager, and logind
-    # removes /run/user/1000 once the last session ends. A runner started as a system service
+    # removes /run/user/<uid> once the last session ends. A runner started as a system service
     # has no login session, so linger is what keeps both alive.
     /usr/bin/loginctl enable-linger ubuntu
 

--- a/app/tests/unit/test_openstack_builder.py
+++ b/app/tests/unit/test_openstack_builder.py
@@ -926,6 +926,10 @@ function configure_system_users() {{
     /usr/sbin/groupadd -f microk8s
     /usr/sbin/groupadd -f docker
     /usr/sbin/usermod --append --groups docker,microk8s,lxd,sudo ubuntu
+    # snapd creates an app's tracking cgroup through the per-user systemd manager, and logind
+    # removes /run/user/1000 once the last session ends. A runner started as a system service
+    # has no login session, so linger is what keeps both alive.
+    /usr/bin/loginctl enable-linger ubuntu
 
     # Create runner user as alias to ubuntu for GARM compatibility.
     # GARM expects a runner user with /home/runner/actions-runner path.


### PR DESCRIPTION
Applicable spec: N/A

### Overview

Enable `loginctl enable-linger` for the `ubuntu` user (aliased as `runner`) in the builder VM's cloud-init, baked into the snapshotted image.

### Rationale

The runner image is shared by two runner managers. github-runner-manager starts the actions runner via `su - ubuntu -c ...`, a login shell, so PAM/logind opens a session for uid 1000 and keeps `user@1000.service` / `/run/user/1000` alive. GARM starts it as a systemd *system* service with no `PAMName=`, so no login session is ever opened.

Without a login session, snapd cannot create a snap's tracking cgroup through the per-user systemd manager (confirmed on a live GARM runner: `juju version` fails with `... is not a snap cgroup for tag ...`, `lxc` fails with `cannot track application process`), and logind reaps `/run/user/1000` once the last session ends, breaking `snapcraft pack` with `PermissionError: [Errno 13] Permission denied: '/run/user/1000'`.

Enabling linger for `ubuntu` starts `user@1000.service` at boot independent of any login session, keeping both alive. Verified live on a GARM runner: enabling linger mid-job flips `juju version`, `lxc list`, and `snapcraft pack` from failing to passing. This is a no-op for github-runner-manager runners, which already get a session.

### Juju Events Changes

None.

### Module Changes

None (application/template change only, no charm code touched).

### Library Changes

None.

### Checklist

- [ ] The [charm style guide](https://documentation.ubuntu.com/juju/3.6/reference/charm) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation for charmhub is updated.
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `senior-review-required`, `documentation`)
- [ ] The docs/changelog.md is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)
- [ ] The application version is incremented in `app/pyproject.toml`

<!-- Explanation for any unchecked items above -->
- Charm style guide / ISD014: not applicable, this change is confined to the cloud-init shell template and its unit test, no charm (`ops`) code touched.
- Charmhub docs: not applicable, no user-facing charm config/behavior changed.
- PR label: left for maintainers to apply.
- Changelog / app version bump: left unticked; can be folded into the next changelog batch/release if maintainers prefer it done here.